### PR TITLE
Join a provided wifi network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ embedded-time = "0.12"
 
 defmt = "0.3"
 defmt-rtt = "0.3"
+heapless = "0.7.16"
 panic-probe = { version = "0.3", features = ["print-rtt"] }
 
 rp2040-hal = { version = "0.5", features=["rt", "eh1_0_alpha"] }

--- a/examples/join.rs
+++ b/examples/join.rs
@@ -126,8 +126,11 @@ fn main() -> ! {
         // ACK on pin x (GPIO10)
         ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
     };
+    let ssid: &str = "SSID";
+    let passphrase: &str = "Passphrase";
+
     let mut wifi = esp32_wroom_rp::wifi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
-    let result = wifi.join("ssid", "passphrase");
+    let result = wifi.join(ssid, passphrase);
     defmt::info!("Join Result: {:?}", result);
 
     defmt::info!("Entering main loop");
@@ -138,6 +141,10 @@ fn main() -> ! {
                 defmt::info!("Get Connection Result: {:?}", byte);
                 let sleep: u32 = 1500;
                 delay.delay_ms(sleep).ok().unwrap();
+
+                if byte == 3 {
+                    defmt::info!("Connected to Network: {:?}", ssid);
+                }
             }
             Err(e) => {
                 defmt::info!("Failed to Get Connection Result: {:?}", e);

--- a/examples/join.rs
+++ b/examples/join.rs
@@ -1,7 +1,7 @@
 //! # ESP32-WROOM-RP Pico Wireless Example
 //!
-//! This application demonstrates how to use the ESP32-WROOM-RP crate to communicate
-//! with a remote ESP32 wifi and retrieve its firmware version.
+//! This application demonstrates how to use the ESP32-WROOM-RP crate to request that
+//! a remote ESP32 WiFi target connects to a particular SSID given a passphrase.
 //!
 //! See the `Cargo.toml` file for Copyright and license details.
 

--- a/examples/join.rs
+++ b/examples/join.rs
@@ -27,6 +27,8 @@ use embedded_time::rate::Extensions;
 use hal::clocks::Clock;
 use hal::pac;
 
+use embedded_hal::delay::blocking::DelayUs;
+
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
@@ -129,5 +131,17 @@ fn main() -> ! {
     defmt::info!("Join Result: {:?}", result);
 
     defmt::info!("Entering main loop");
-    loop {}
+
+    loop {
+        match wifi.get_connection_status() {
+            Ok(byte) => {
+                defmt::info!("Get Connection Result: {:?}", byte);
+                let sleep: u32 = 1500;
+                delay.delay_ms(sleep).ok().unwrap();
+            }
+            Err(e) => {
+                defmt::info!("Failed to Get Connection Result: {:?}", e);
+            }
+        }
+    }
 }

--- a/examples/join.rs
+++ b/examples/join.rs
@@ -1,0 +1,133 @@
+//! # ESP32-WROOM-RP Pico Wireless Example
+//!
+//! This application demonstrates how to use the ESP32-WROOM-RP crate to communicate
+//! with a remote ESP32 wifi and retrieve its firmware version.
+//!
+//! See the `Cargo.toml` file for Copyright and license details.
+
+#![no_std]
+#![no_main]
+
+extern crate esp32_wroom_rp;
+
+// The macro for our start-up function
+use cortex_m_rt::entry;
+
+// Needed for debug output symbols to be linked in binary image
+use defmt_rtt as _;
+
+use panic_probe as _;
+
+// Alias for our HAL crate
+use rp2040_hal as hal;
+
+use eh_02::spi::MODE_0;
+use embedded_time::fixed_point::FixedPoint;
+use embedded_time::rate::Extensions;
+use hal::clocks::Clock;
+use hal::pac;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+/// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
+/// if your board has a different frequency
+const XTAL_FREQ_HZ: u32 = 12_000_000u32;
+
+// Until cortex_m implements the DelayUs trait needed for embedded-hal-1.0.0,
+// provide a wrapper around it
+pub struct DelayWrap(cortex_m::delay::Delay);
+
+impl embedded_hal::delay::blocking::DelayUs for DelayWrap {
+    type Error = core::convert::Infallible;
+
+    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+        self.0.delay_us(us);
+        Ok(())
+    }
+
+    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+        self.0.delay_ms(ms);
+        Ok(())
+    }
+}
+
+/// Entry point to our bare-metal application.
+///
+/// The `#[entry]` macro ensures the Cortex-M start-up code calls this function
+/// as soon as all global variables are initialized.
+#[entry]
+fn main() -> ! {
+    // Grab our singleton objects
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    // Set up the watchdog driver - needed by the clock setup code
+    let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+
+    // Configure the clocks
+    let clocks = hal::clocks::init_clocks_and_plls(
+        XTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = DelayWrap(cortex_m::delay::Delay::new(
+        core.SYST,
+        clocks.system_clock.freq().integer(),
+    ));
+
+    // The single-cycle I/O block controls our GPIO pins
+    let sio = hal::Sio::new(pac.SIO);
+
+    // Set the pins to their default state
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    defmt::info!("ESP32-WROOM-RP get NINA firmware version example");
+
+    // These are implicitly used by the spi driver if they are in the correct mode
+    let spi_miso = pins.gpio16.into_mode::<hal::gpio::FunctionSpi>();
+    let spi_sclk = pins.gpio18.into_mode::<hal::gpio::FunctionSpi>();
+    let spi_mosi = pins.gpio19.into_mode::<hal::gpio::FunctionSpi>();
+
+    let spi = hal::Spi::<_, _, 8>::new(pac.SPI0);
+
+    // Exchange the uninitialized SPI driver for an initialized one
+    let spi = spi.init(
+        &mut pac.RESETS,
+        clocks.peripheral_clock.freq(),
+        8_000_000u32.Hz(),
+        &MODE_0,
+    );
+
+    let esp_pins = esp32_wroom_rp::gpio::EspControlPins {
+        // CS on pin x (GPIO7)
+        cs: pins.gpio7.into_mode::<hal::gpio::PushPullOutput>(),
+        // GPIO0 on pin x (GPIO2)
+        gpio0: pins.gpio2.into_mode::<hal::gpio::PushPullOutput>(),
+        // RESETn on pin x (GPIO11)
+        resetn: pins.gpio11.into_mode::<hal::gpio::PushPullOutput>(),
+        // ACK on pin x (GPIO10)
+        ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
+    };
+    let mut wifi = esp32_wroom_rp::wifi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
+    let result = wifi.join("ssid", "passphrase");
+    defmt::info!("Join Result: {:?}", result);
+
+    defmt::info!("Entering main loop");
+    loop {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,10 @@ where
     fn firmware_version(&mut self) -> Result<FirmwareVersion, self::Error> {
         self.protocol_handler.get_fw_version()
     }
+
+    fn join(&mut self) -> Result<(), Error> {
+        self.protocol_handler.set_passphrase()
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,6 @@ use protocol::ProtocolInterface;
 use defmt::{write, Format, Formatter};
 use embedded_hal::delay::blocking::DelayUs;
 
-// This is just a placeholder for now.
-type Params = [u8; 5];
 
 #[derive(Debug)]
 pub enum Error {
@@ -178,8 +176,6 @@ where
         self.protocol_handler.init();
         self.reset(delay);
     }
-
-    fn configure() {}
 
     fn reset<D: DelayUs>(&mut self, delay: &mut D) {
         self.protocol_handler.reset(delay)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,8 +189,8 @@ where
         self.protocol_handler.get_fw_version()
     }
 
-    fn join(&mut self) -> Result<(), Error> {
-        self.protocol_handler.set_passphrase()
+    fn join(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error> {
+        self.protocol_handler.set_passphrase(ssid, passphrase)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,10 @@ where
     fn join(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error> {
         self.protocol_handler.set_passphrase(ssid, passphrase)
     }
+
+    fn get_connection_status(&mut self) -> Result<u8, self::Error> {
+        self.protocol_handler.get_conn_status()
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ use protocol::ProtocolInterface;
 use defmt::{write, Format, Formatter};
 use embedded_hal::delay::blocking::DelayUs;
 
+const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 
 #[derive(Debug)]
 pub enum Error {
@@ -133,12 +134,12 @@ pub struct FirmwareVersion {
 }
 
 impl FirmwareVersion {
-    fn new(version: [u8; 8]) -> FirmwareVersion {
+    fn new(version: [u8; ARRAY_LENGTH_PLACEHOLDER]) -> FirmwareVersion {
         Self::parse(version)
     }
 
     // Takes in 8 bytes (e.g. 1.7.4) and returns a FirmwareVersion instance
-    fn parse(version: [u8; 8]) -> FirmwareVersion {
+    fn parse(version: [u8; ARRAY_LENGTH_PLACEHOLDER]) -> FirmwareVersion {
         let major: u8;
         let minor: u8;
         let patch: u8;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -24,14 +24,14 @@ pub trait NinaParam {
     // Is this the final parameter being sent for this NinaCommand? TODO: is generic type LastParam even needed?
     type LastParam;
     // The actual parameter data to send over the data bus
-    type Data;
+    type Data: IntoIterator<Item = u8>;
 
     type LengthAsBytes: IntoIterator<Item = u8>;
 
     fn length_size(&mut self) -> Self::LengthSize;
     fn length(&mut self) -> Self::Length;
     fn last_param(&mut self) -> Self::LastParam;
-    // fn data(&mut self) -> Self::Data;
+    fn data(&mut self) -> Self::Data;
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes;
 }
@@ -40,28 +40,28 @@ pub struct NinaByteParam {
     length_size: u8,
     length: u8,
     last_param: bool,
-    data: Vec<u8, 1>,
+    data: [u8; 1],
 }
 
 pub struct NinaWordParam {
     length_size: u8,
     length: u8,
     last_param: bool,
-    data: Vec<u8, 2>,
+    data: [u8; 2],
 }
 
 pub struct NinaArrayParam {
     length_size: u8,
     length: u16,
     last_param: bool,
-    data: Vec<u8, MAX_NINA_PARAM_LENGTH>,
+    data: [u8; MAX_NINA_PARAM_LENGTH],
 }
 
 impl NinaParam for NinaByteParam {
     type LengthSize = u8;
     type Length = u8;
     type LastParam = bool;
-    type Data = Vec<u8, 1>;
+    type Data = [u8; 1];
     type LengthAsBytes = [u8; 1];
 
     fn length_size(&mut self) -> Self::LengthSize {
@@ -73,9 +73,9 @@ impl NinaParam for NinaByteParam {
     fn last_param(&mut self) -> Self::LastParam {
         self.last_param
     }
-    // fn data(&mut self) -> Self::Data {
-    //     self.data
-    // }
+    fn data(&mut self) -> Self::Data {
+        self.data
+    }
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
         [self.length() as u8]
@@ -86,7 +86,7 @@ impl NinaParam for NinaWordParam {
     type LengthSize = u8;
     type Length = u8;
     type LastParam = bool;
-    type Data = Vec<u8, 2>;
+    type Data = [u8; 2];
     type LengthAsBytes = [u8; 1];
 
     fn length_size(&mut self) -> Self::LengthSize {
@@ -98,9 +98,9 @@ impl NinaParam for NinaWordParam {
     fn last_param(&mut self) -> Self::LastParam {
         self.last_param
     }
-    // fn data(&mut self) -> Self::Data {
-    //     self.data
-    // }
+    fn data(&mut self) -> Self::Data {
+        self.data
+    }
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
         [self.length() as u8]
@@ -111,7 +111,7 @@ impl NinaParam for NinaArrayParam {
     type LengthSize = u8;
     type Length = u16;
     type LastParam = bool;
-    type Data = Vec<u8, MAX_NINA_PARAM_LENGTH>;
+    type Data = [u8; MAX_NINA_PARAM_LENGTH];
     type LengthAsBytes = [u8; 2];
 
     fn length_size(&mut self) -> Self::LengthSize {
@@ -123,9 +123,9 @@ impl NinaParam for NinaArrayParam {
     fn last_param(&mut self) -> Self::LastParam {
         self.last_param
     }
-    // fn data(&mut self) -> Self::Data {
-    //     self.data
-    // }
+    fn data(&mut self) -> Self::Data {
+        self.data
+    }
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
         [
@@ -154,7 +154,7 @@ pub trait ProtocolInterface {
     fn check_start_cmd(&mut self) -> Result<bool, self::Error>;
     fn read_and_check_byte(&mut self, check_byte: u8) -> Result<bool, self::Error>;
     fn send_param<P: NinaParam>(&mut self, param: P) -> Result<(), self::Error>;
-    fn send_param_length<P: NinaParam>(&mut self, param: P) -> Result<(), self::Error>;
+    fn send_param_length<P: NinaParam>(&mut self, param: &mut P) -> Result<(), self::Error>;
 }
 
 #[derive(Debug, Default)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -47,7 +47,15 @@ pub struct NinaWordParam {
     data: Vec<u8, 2>,
 }
 
-pub struct NinaArrayParam {
+// Used for params that are smaller than 255 bytes
+pub struct NinaSmallArrayParam {
+    // length_size: u8,
+    length: u8,
+    // last_param: bool,
+    data: Vec<u8, MAX_NINA_PARAM_LENGTH>,
+}
+// Used for params that can be larger than 255 bytes up to MAX_NINA_PARAM_LENGTH
+pub struct NinaLargeArrayParam {
     // length_size: u8,
     length: u16,
     // last_param: bool,
@@ -96,13 +104,34 @@ impl NinaParam for NinaWordParam {
     }
 }
 
-impl NinaParam for NinaArrayParam {
+impl NinaParam for NinaSmallArrayParam {
+    type Data = Vec<u8, MAX_NINA_PARAM_LENGTH>;
+    type LengthAsBytes = [u8; 1];
+
+    fn new(data: &str) -> NinaSmallArrayParam {
+        let data_as_bytes: Vec<u8, MAX_NINA_PARAM_LENGTH> = String::from(data).into_bytes();
+        NinaSmallArrayParam {
+            length: data_as_bytes.len() as u8,
+            data: data_as_bytes,
+        }
+    }
+
+    fn data(&mut self) -> &[u8] {
+        self.data.as_slice()
+    }
+
+    fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
+        [self.length as u8]
+    }
+}
+
+impl NinaParam for NinaLargeArrayParam {
     type Data = Vec<u8, MAX_NINA_PARAM_LENGTH>;
     type LengthAsBytes = [u8; 2];
 
-    fn new(data: &str) -> NinaArrayParam {
+    fn new(data: &str) -> NinaLargeArrayParam {
         let data_as_bytes: Vec<u8, MAX_NINA_PARAM_LENGTH> = String::from(data).into_bytes();
-        NinaArrayParam {
+        NinaLargeArrayParam {
             length: data_as_bytes.len() as u16,
             data: data_as_bytes,
         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,32 +1,24 @@
 use super::*;
 
-use eh_02::blocking::spi::Transfer;
 use embedded_hal::delay::blocking::DelayUs;
 
 use heapless::{String, Vec};
 
-//pub const PARAMS_ARRAY_LEN: usize = 8;
 pub const MAX_NINA_PARAM_LENGTH: usize = 255;
 
 #[repr(u8)]
 #[derive(Debug)]
 pub enum NinaCommand {
-    StartClientTcp = 0x2Du8,
     GetFwVersion = 0x37u8,
     SetPassphrase = 0x11u8,
     GetConnStatus = 0x20u8,
 }
 
 pub trait NinaParam {
-    // The actual parameter data to send over the data bus
-    type Data: IntoIterator<Item = u8>;
-
     // Length of parameter in bytes
     type LengthAsBytes: IntoIterator<Item = u8>;
 
-    fn new(data: &str) -> Self
-    where
-        Self:;
+    fn new(data: &str) -> Self;
 
     fn data(&mut self) -> &[u8];
 
@@ -34,41 +26,32 @@ pub trait NinaParam {
 }
 
 pub struct NinaByteParam {
-    // length_size: u8,
     length: u8,
-    // last_param: bool,
     data: Vec<u8, 1>,
 }
 
 pub struct NinaWordParam {
-    // length_size: u8,
     length: u8,
-    // last_param: bool,
     data: Vec<u8, 2>,
 }
 
 // Used for params that are smaller than 255 bytes
 pub struct NinaSmallArrayParam {
-    // length_size: u8,
     length: u8,
-    // last_param: bool,
     data: Vec<u8, MAX_NINA_PARAM_LENGTH>,
 }
 // Used for params that can be larger than 255 bytes up to MAX_NINA_PARAM_LENGTH
 pub struct NinaLargeArrayParam {
-    // length_size: u8,
     length: u16,
-    // last_param: bool,
     data: Vec<u8, MAX_NINA_PARAM_LENGTH>,
 }
 
 impl NinaParam for NinaByteParam {
-    type Data = Vec<u8, 1>;
     type LengthAsBytes = [u8; 1];
 
-    fn new(data: &str) -> NinaByteParam {
+    fn new(data: &str) -> Self {
         let data_as_bytes: Vec<u8, 1> = String::from(data).into_bytes();
-        NinaByteParam {
+        Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
         }
@@ -84,12 +67,11 @@ impl NinaParam for NinaByteParam {
 }
 
 impl NinaParam for NinaWordParam {
-    type Data = Vec<u8, 2>;
     type LengthAsBytes = [u8; 1];
 
-    fn new(data: &str) -> NinaWordParam {
+    fn new(data: &str) -> Self {
         let data_as_bytes: Vec<u8, 2> = String::from(data).into_bytes();
-        NinaWordParam {
+        Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
         }
@@ -105,12 +87,11 @@ impl NinaParam for NinaWordParam {
 }
 
 impl NinaParam for NinaSmallArrayParam {
-    type Data = Vec<u8, MAX_NINA_PARAM_LENGTH>;
     type LengthAsBytes = [u8; 1];
 
-    fn new(data: &str) -> NinaSmallArrayParam {
+    fn new(data: &str) -> Self {
         let data_as_bytes: Vec<u8, MAX_NINA_PARAM_LENGTH> = String::from(data).into_bytes();
-        NinaSmallArrayParam {
+        Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
         }
@@ -126,12 +107,11 @@ impl NinaParam for NinaSmallArrayParam {
 }
 
 impl NinaParam for NinaLargeArrayParam {
-    type Data = Vec<u8, MAX_NINA_PARAM_LENGTH>;
     type LengthAsBytes = [u8; 2];
 
-    fn new(data: &str) -> NinaLargeArrayParam {
+    fn new(data: &str) -> Self {
         let data_as_bytes: Vec<u8, MAX_NINA_PARAM_LENGTH> = String::from(data).into_bytes();
-        NinaLargeArrayParam {
+        Self {
             length: data_as_bytes.len() as u16,
             data: data_as_bytes,
         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -31,8 +31,8 @@ pub struct NinaByteParam {
     data: Vec<u8, 1>,
 }
 
-
 // Used for 2-byte params
+pub struct NinaWordParam {
     length: u8,
     data: Vec<u8, 2>,
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -25,6 +25,7 @@ pub trait NinaParam {
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes;
 }
 
+// Used for single byte params
 pub struct NinaByteParam {
     length: u8,
     data: Vec<u8, 1>,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -31,7 +31,8 @@ pub struct NinaByteParam {
     data: Vec<u8, 1>,
 }
 
-pub struct NinaWordParam {
+
+// Used for 2-byte params
     length: u8,
     data: Vec<u8, 2>,
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -17,20 +17,11 @@ pub enum NinaCommand {
 }
 
 pub trait NinaParam {
-    // The size of the param length field, 1 or 2 bytes
-    type LengthSize;
-    // The actual length value of the Data
-    type Length;
-    // Is this the final parameter being sent for this NinaCommand? TODO: is generic type LastParam even needed?
-    type LastParam;
     // The actual parameter data to send over the data bus
     type Data: IntoIterator<Item = u8>;
 
+    // Length of parameter in bytes
     type LengthAsBytes: IntoIterator<Item = u8>;
-
-    fn length_size(&mut self) -> Self::LengthSize;
-    fn length(&mut self) -> Self::Length;
-    fn last_param(&mut self) -> Self::LastParam;
     fn data(&mut self) -> Self::Data;
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes;
@@ -58,79 +49,43 @@ pub struct NinaArrayParam {
 }
 
 impl NinaParam for NinaByteParam {
-    type LengthSize = u8;
-    type Length = u8;
-    type LastParam = bool;
     type Data = [u8; 1];
     type LengthAsBytes = [u8; 1];
 
-    fn length_size(&mut self) -> Self::LengthSize {
-        self.length_size
-    }
-    fn length(&mut self) -> Self::Length {
-        self.length
-    }
-    fn last_param(&mut self) -> Self::LastParam {
-        self.last_param
-    }
     fn data(&mut self) -> Self::Data {
         self.data
     }
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
-        [self.length() as u8]
+        [self.length as u8]
     }
 }
 
 impl NinaParam for NinaWordParam {
-    type LengthSize = u8;
-    type Length = u8;
-    type LastParam = bool;
     type Data = [u8; 2];
     type LengthAsBytes = [u8; 1];
 
-    fn length_size(&mut self) -> Self::LengthSize {
-        self.length_size
-    }
-    fn length(&mut self) -> Self::Length {
-        self.length
-    }
-    fn last_param(&mut self) -> Self::LastParam {
-        self.last_param
-    }
     fn data(&mut self) -> Self::Data {
         self.data
     }
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
-        [self.length() as u8]
+        [self.length as u8]
     }
 }
 
 impl NinaParam for NinaArrayParam {
-    type LengthSize = u8;
-    type Length = u16;
-    type LastParam = bool;
     type Data = [u8; MAX_NINA_PARAM_LENGTH];
     type LengthAsBytes = [u8; 2];
 
-    fn length_size(&mut self) -> Self::LengthSize {
-        self.length_size
-    }
-    fn length(&mut self) -> Self::Length {
-        self.length
-    }
-    fn last_param(&mut self) -> Self::LastParam {
-        self.last_param
-    }
     fn data(&mut self) -> Self::Data {
         self.data
     }
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
         [
-            ((self.length() & 0xff00) >> 8) as u8,
-            (self.length() & 0xff) as u8,
+            ((self.length & 0xff00) >> 8) as u8,
+            (self.length & 0xff) as u8,
         ]
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -143,7 +143,7 @@ pub trait ProtocolInterface {
         &mut self,
         cmd: NinaCommand,
         num_params: u8,
-    ) -> Result<[u8; 8], self::Error>;
+    ) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], self::Error>;
     fn send_end_cmd(&mut self) -> Result<(), self::Error>;
 
     fn get_param(&mut self) -> Result<u8, self::Error>;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -14,6 +14,7 @@ pub enum NinaCommand {
     StartClientTcp = 0x2Du8,
     GetFwVersion = 0x37u8,
     SetPassphrase = 0x11u8,
+    GetConnStatus = 0x20u8,
 }
 
 pub trait NinaParam {
@@ -124,6 +125,7 @@ pub trait ProtocolInterface {
     fn reset<D: DelayUs>(&mut self, delay: &mut D);
     fn get_fw_version(&mut self) -> Result<FirmwareVersion, self::Error>;
     fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error>;
+    fn get_conn_status(&mut self) -> Result<u8, self::Error>;
 
     fn send_cmd(&mut self, cmd: NinaCommand, num_params: u8) -> Result<(), self::Error>;
     fn wait_response_cmd(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -40,6 +40,7 @@ pub struct NinaSmallArrayParam {
     length: u8,
     data: Vec<u8, MAX_NINA_PARAM_LENGTH>,
 }
+
 // Used for params that can be larger than 255 bytes up to MAX_NINA_PARAM_LENGTH
 pub struct NinaLargeArrayParam {
     length: u16,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -16,6 +16,7 @@ pub trait ProtocolInterface {
     fn init(&mut self);
     fn reset<D: DelayUs>(&mut self, delay: &mut D);
     fn get_fw_version(&mut self) -> Result<FirmwareVersion, self::Error>;
+    fn set_passphrase(&mut self) -> Result<(), Error>;
 
     fn send_cmd(&mut self, cmd: NinaCommand, num_params: u8) -> Result<(), self::Error>;
     fn wait_response_cmd(

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -2,7 +2,7 @@
 
 use super::gpio::EspControlInterface;
 use super::protocol::{
-    NinaArrayParam, NinaByteParam, NinaCommand, NinaParam, NinaProtocolHandler, ProtocolInterface,
+    NinaCommand, NinaParam, NinaProtocolHandler, NinaSmallArrayParam, ProtocolInterface,
 };
 use super::{Error, FirmwareVersion, WifiCommon};
 
@@ -97,10 +97,10 @@ where
 
         self.send_cmd(NinaCommand::SetPassphrase, 2).ok().unwrap();
 
-        let ssid_param = NinaArrayParam::new(ssid);
+        let ssid_param = NinaSmallArrayParam::new(ssid);
         self.send_param(ssid_param);
 
-        let passphrase_param = NinaArrayParam::new(passphrase);
+        let passphrase_param = NinaSmallArrayParam::new(passphrase);
         self.send_param(passphrase_param);
 
         self.send_end_cmd();

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -214,16 +214,20 @@ where
         }
     }
 
-    fn send_param<P: NinaParam>(&mut self, param: P) -> Result<(), self::Error> {
+    fn send_param<P: NinaParam>(&mut self, mut param: P) -> Result<(), self::Error> {
+        self.send_param_length(&mut param)?;
+
+        for byte in param.data() {
+            self.bus.transfer(&mut [byte]).ok().unwrap();
+        }
         Ok(())
     }
 
-    fn send_param_length<P: NinaParam>(&mut self, mut param: P) -> Result<(), self::Error> {
+    fn send_param_length<P: NinaParam>(&mut self, param: &mut P) -> Result<(), self::Error> {
         // TODO: use eh2's Transfer which has separate read/write bufs
 
         for byte in param.length_as_bytes().into_iter() {
-            let write_buf: &mut [u8] = &mut [byte];
-            self.bus.transfer(write_buf).ok().unwrap();
+            self.bus.transfer(&mut [byte]).ok().unwrap();
         }
         Ok(())
     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -259,7 +259,6 @@ where
     }
 
     fn send_param_length<P: NinaParam>(&mut self, param: &mut P) -> Result<(), self::Error> {
-
         for byte in param.length_as_bytes().into_iter() {
             self.bus.transfer(&mut [byte]).ok().unwrap();
         }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -4,7 +4,7 @@ use super::gpio::EspControlInterface;
 use super::protocol::{
     NinaCommand, NinaParam, NinaProtocolHandler, NinaSmallArrayParam, ProtocolInterface,
 };
-use super::{Error, FirmwareVersion, WifiCommon};
+use super::{Error, FirmwareVersion, WifiCommon, ARRAY_LENGTH_PLACEHOLDER};
 
 use eh_02::blocking::spi::Transfer;
 use embedded_hal::delay::blocking::DelayUs;
@@ -154,7 +154,7 @@ where
         &mut self,
         cmd: NinaCommand,
         num_params: u8,
-    ) -> Result<[u8; 8], self::Error> {
+    ) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], self::Error> {
         self.check_start_cmd().ok().unwrap();
 
         let result = self.read_and_check_byte(cmd as u8 | ControlByte::Reply as u8)?;
@@ -178,7 +178,7 @@ where
             //return Err(SPIError::Misc);
         }
 
-        let mut params: [u8; 8] = [0; 8];
+        let mut params: [u8; ARRAY_LENGTH_PLACEHOLDER] = [0; 8];
         for i in 0..num_params_to_read {
             params[i] = self.get_param().ok().unwrap()
         }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -120,7 +120,7 @@ where
     fn get_conn_status(&mut self) -> Result<u8, self::Error> {
         self.control_pins.wait_for_esp_select();
 
-        self.send_cmd(NinaCommand::GetConnStatus, 2).ok().unwrap();
+        self.send_cmd(NinaCommand::GetConnStatus, 0).ok().unwrap();
 
         self.control_pins.esp_deselect();
         self.control_pins.wait_for_esp_select();

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -48,6 +48,10 @@ where
     pub fn firmware_version(&mut self) -> Result<FirmwareVersion, Error> {
         self.common.firmware_version()
     }
+
+    pub fn join(&mut self) -> Result<(), Error> {
+        self.common.join()
+    }
 }
 
 // All SPI-specific aspects of the NinaProtocolHandler go here in this struct impl
@@ -80,6 +84,10 @@ where
         self.control_pins.esp_deselect();
 
         Ok(FirmwareVersion::new(bytes)) // e.g. 1.7.4
+    }
+
+    fn set_passphrase(&mut self) -> Result<(), self::Error> {
+      Ok(())
     }
 
     fn send_cmd(&mut self, cmd: NinaCommand, num_params: u8) -> Result<(), self::Error> {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -51,6 +51,7 @@ where
         self.common.firmware_version()
     }
 
+    /// Joins a WiFi network given an SSID and a Passphrase
     pub fn join(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error> {
         self.common.join(ssid, passphrase)
     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -54,6 +54,10 @@ where
     pub fn join(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error> {
         self.common.join(ssid, passphrase)
     }
+
+    pub fn get_connection_status(&mut self) -> Result<u8, Error> {
+        self.common.get_connection_status()
+    }
 }
 
 // All SPI-specific aspects of the NinaProtocolHandler go here in this struct impl
@@ -111,6 +115,20 @@ where
 
         self.control_pins.esp_deselect();
         Ok(())
+    }
+
+    fn get_conn_status(&mut self) -> Result<u8, self::Error> {
+        self.control_pins.wait_for_esp_select();
+
+        self.send_cmd(NinaCommand::GetConnStatus, 2).ok().unwrap();
+
+        self.control_pins.esp_deselect();
+        self.control_pins.wait_for_esp_select();
+
+        let result = self.wait_response_cmd(NinaCommand::GetConnStatus, 1)?;
+        self.control_pins.esp_deselect();
+
+        Ok(result[0])
     }
 
     fn send_cmd(&mut self, cmd: NinaCommand, num_params: u8) -> Result<(), self::Error> {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -259,7 +259,6 @@ where
     }
 
     fn send_param_length<P: NinaParam>(&mut self, param: &mut P) -> Result<(), self::Error> {
-        // TODO: use eh2's Transfer which has separate read/write bufs
 
         for byte in param.length_as_bytes().into_iter() {
             self.bus.transfer(&mut [byte]).ok().unwrap();


### PR DESCRIPTION
## Description

This Pull Request satisfies the following criteria as defined in https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues/15:

- Consumers of the crate can provide an SSID/Passphrase pair and successfully join a non-enterprise WiFi network.
- Adheres to [interface specification](https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/discussions/10#:~:text=join%20%2D%20joins%20a%20WIFI%20network)

by adding new public methods to the `Wifi` interface:
- `join(ssid: &str, passphrase: &str) -> Result<(), Error>`
- `get_connection_status()` -> Result<u8, self::Error>

This Pull Request also adds:
-  A new trait `NinaParam` which defines an interface for handling data to be sent over a serial bus as well as a number of structs that implement the new trait
   - This is a step in the direction of improving our low level interfaces for https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues/18
- A new example at `/examples/join.rs` which will join a WiFi network and then check the status of that connection
  - `cargo run --example join`
 
#### GitHub Issue: https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues/15

### Changes
* Adds `Join` method on the `Wifi` struct
* Adds `get_connection_status` method on the `Wifi` struct
* Adds `NinaParam` trait and struct implementations
* Adds `join.rs` example

### Testing Strategy

Output of `cargo run --example join`

```Rust
INFO  ESP32-WROOM-RP get NINA firmware version example
└─ join::__cortex_m_rt_main @ examples/join.rs:102
INFO  Join Result: Ok(())
└─ join::__cortex_m_rt_main @ examples/join.rs:131
INFO  Entering main loop
└─ join::__cortex_m_rt_main @ examples/join.rs:133
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ examples/join.rs:138
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ examples/join.rs:138
INFO  Get Connection Result: 3 // status connected
└─ join::__cortex_m_rt_main @ examples/join.rs:138
```
