### PR TITLE
Leave a previously joined WiFi network

### DIFF
--- a/examples/join.rs
+++ b/examples/join.rs
@@ -1,7 +1,8 @@
 //! # ESP32-WROOM-RP Pico Wireless Example
 //!
 //! This application demonstrates how to use the ESP32-WROOM-RP crate to request that
-//! a remote ESP32 WiFi target connects to a particular SSID given a passphrase.
+//! a remote ESP32 WiFi target connects to a particular SSID given a passphrase
+//! and then leaves (disconnects) that same network.
 //!
 //! See the `Cargo.toml` file for Copyright and license details.
 
@@ -99,7 +100,7 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    defmt::info!("ESP32-WROOM-RP get NINA firmware version example");
+    defmt::info!("ESP32-WROOM-RP join/leave WiFi network");
 
     // These are implicitly used by the spi driver if they are in the correct mode
     let spi_miso = pins.gpio16.into_mode::<hal::gpio::FunctionSpi>();
@@ -144,6 +145,12 @@ fn main() -> ! {
 
                 if byte == 3 {
                     defmt::info!("Connected to Network: {:?}", ssid);
+
+                    defmt::info!("Sleeping for 5 seconds before disconnecting...");
+                    delay.delay_ms(5000).ok().unwrap();
+
+                    wifi.leave().ok().unwrap();
+                    defmt::info!("Disconnected from Network: {:?}", ssid);
                 }
             }
             Err(e) => {

--- a/examples/join.rs
+++ b/examples/join.rs
@@ -150,6 +150,7 @@ fn main() -> ! {
                     delay.delay_ms(5000).ok().unwrap();
 
                     wifi.leave().ok().unwrap();
+                } else if byte == 6 {
                     defmt::info!("Disconnected from Network: {:?}", ssid);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,10 @@ where
         self.protocol_handler.set_passphrase(ssid, passphrase)
     }
 
+    fn leave(&mut self) -> Result<(), Error> {
+        self.protocol_handler.disconnect()
+    }
+
     fn get_connection_status(&mut self) -> Result<u8, self::Error> {
         self.protocol_handler.get_conn_status()
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -186,8 +186,7 @@ pub trait ProtocolInterface {
     ) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], self::Error>;
     fn send_end_cmd(&mut self) -> Result<(), self::Error>;
 
-    fn get_param(&mut self) -> Result<u8, self::Error>;
-    fn read_byte(&mut self) -> Result<u8, self::Error>;
+    fn get_byte(&mut self) -> Result<u8, self::Error>;
     fn wait_for_byte(&mut self, wait_byte: u8) -> Result<bool, self::Error>;
     fn check_start_cmd(&mut self) -> Result<bool, self::Error>;
     fn read_and_check_byte(&mut self, check_byte: u8) -> Result<bool, self::Error>;


### PR DESCRIPTION
## Description
This PR adds the ability to leave (disconnect) from a non-enterprise grade WiFi network that was previously joined. It also provides an example in `examples/join.rs` of joining and leaving a network.

#### GitHub Issue: Closes #16 

### Changes
* Adds a `leave()` public method to `Wifi` struct
* Adds a new associated function to `NinaParam` to allow for the creation of a new instance from a `&[u8]` byte slice
* Renames method `get_param()` in `ProtocolInterface` to `get_byte()` for more apt naming
* Extends `examples/join.rs` demonstrating the use of the `leave()` method

### Testing Strategy
Output of `cargo run --example join`
```Rust
INFO  ESP32-WROOM-RP join/leave WiFi network
└─ join::__cortex_m_rt_main @ examples/join.rs:103
INFO  Join Result: Ok(())
└─ join::__cortex_m_rt_main @ examples/join.rs:135
INFO  Entering main loop
└─ join::__cortex_m_rt_main @ examples/join.rs:137
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ examples/join.rs:142
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ examples/join.rs:142
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ examples/join.rs:142
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ examples/join.rs:142
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ examples/join.rs:142
INFO  Get Connection Result: 3
└─ join::__cortex_m_rt_main @ examples/join.rs:142
INFO  Connected to Network: "Zion"
└─ join::__cortex_m_rt_main @ examples/join.rs:147
INFO  Sleeping for 5 seconds before disconnecting...
└─ join::__cortex_m_rt_main @ examples/join.rs:149
INFO  Disconnected from Network: "Zion"
└─ join::__cortex_m_rt_main @ examples/join.rs:153
INFO  Get Connection Result: 6
```
Observe connection `result == 6` which confirms the client is disconnected from network Zion.

### Concerns
Nothing obvious