### PR TITLE
Improve NINA protocol function architecture 2

### DIFF
--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -115,10 +115,9 @@ fn main() -> ! {
         // ACK on pin x (GPIO10)
         ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
     };
-    let passphrase: &str = "Passphrase";
 
     let mut wifi = esp32_wroom_rp::wifi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
-    let result = wifi.join(SSID, PASSPHRASE);
+    let result = wifi.join(SSID, PADSSPHRASE);
     defmt::info!("Join Result: {:?}", result);
 
     defmt::info!("Entering main loop");

--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -29,12 +29,8 @@ use embedded_time::rate::Extensions;
 use hal::clocks::Clock;
 use hal::pac;
 
-<<<<<<< HEAD:cross/join/src/main.rs
 use embedded_hal::spi::MODE_0;
 use embedded_hal::blocking::delay::DelayMs;
-=======
-use embedded_hal::delay::blocking::DelayUs;
->>>>>>> 50a5b0a (add Operation):examples/join.rs
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -29,8 +29,12 @@ use embedded_time::rate::Extensions;
 use hal::clocks::Clock;
 use hal::pac;
 
+<<<<<<< HEAD:cross/join/src/main.rs
 use embedded_hal::spi::MODE_0;
 use embedded_hal::blocking::delay::DelayMs;
+=======
+use embedded_hal::delay::blocking::DelayUs;
+>>>>>>> 50a5b0a (add Operation):examples/join.rs
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -117,7 +117,7 @@ fn main() -> ! {
     };
 
     let mut wifi = esp32_wroom_rp::wifi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
-    let result = wifi.join(SSID, PADSSPHRASE);
+    let result = wifi.join(SSID, PASSPHRASE);
     defmt::info!("Join Result: {:?}", result);
 
     defmt::info!("Entering main loop");

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -9,7 +9,7 @@ use heapless::{String, Vec};
 pub const MAX_NINA_PARAM_LENGTH: usize = 255;
 
 #[repr(u8)]
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum NinaCommand {
     GetFwVersion = 0x37u8,
     SetPassphrase = 0x11u8,
@@ -30,6 +30,35 @@ pub trait NinaParam {
     fn length_as_bytes(&self) -> Self::LengthAsBytes;
 
     fn length(&self) -> u16;
+}
+
+// Used for Nina protocol commands with no parameters
+pub struct NinaNoParams {
+    _placeholder: u8,
+}
+
+impl NinaParam for NinaNoParams {
+    type LengthAsBytes = [u8; 0];
+
+    fn new(data: &str) -> Self {
+        Self { _placeholder: 0 }
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Self {
+        Self { _placeholder: 0 }
+    }
+
+    fn data(&self) -> &[u8] {
+        &[0u8]
+    }
+
+    fn length_as_bytes(&self) -> Self::LengthAsBytes {
+        []
+    }
+
+    fn length(&self) -> u16 {
+        0u16
+    }
 }
 
 // Used for single byte params

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -22,13 +22,14 @@ pub trait NinaParam {
     type LengthAsBytes: IntoIterator<Item = u8>;
 
     fn new(data: &str) -> Self;
+
     fn from_bytes(bytes: &[u8]) -> Self;
 
-    fn data(&mut self) -> &[u8];
+    fn data(&self) -> &[u8];
 
-    fn length_as_bytes(&mut self) -> Self::LengthAsBytes;
+    fn length_as_bytes(&self) -> Self::LengthAsBytes;
 
-    fn length(self) -> u16;
+    fn length(&self) -> u16;
 }
 
 // Used for single byte params
@@ -75,15 +76,15 @@ impl NinaParam for NinaByteParam {
         }
     }
 
-    fn data(&mut self) -> &[u8] {
+    fn data(&self) -> &[u8] {
         self.data.as_slice()
     }
 
-    fn length(self) -> u16 {
+    fn length(&self) -> u16 {
         self.length as u16
     }
 
-    fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
+    fn length_as_bytes(&self) -> Self::LengthAsBytes {
         [self.length as u8]
     }
 }
@@ -108,15 +109,15 @@ impl NinaParam for NinaWordParam {
         }
     }
 
-    fn data(&mut self) -> &[u8] {
+    fn data(&self) -> &[u8] {
         self.data.as_slice()
     }
 
-    fn length(self) -> u16 {
+    fn length(&self) -> u16 {
         self.length as u16
     }
 
-    fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
+    fn length_as_bytes(&self) -> Self::LengthAsBytes {
         [self.length as u8]
     }
 }
@@ -141,15 +142,15 @@ impl NinaParam for NinaSmallArrayParam {
         }
     }
 
-    fn data(&mut self) -> &[u8] {
+    fn data(&self) -> &[u8] {
         self.data.as_slice()
     }
 
-    fn length(self) -> u16 {
+    fn length(&self) -> u16 {
         self.length as u16
     }
 
-    fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
+    fn length_as_bytes(&self) -> Self::LengthAsBytes {
         [self.length as u8]
     }
 }
@@ -174,15 +175,15 @@ impl NinaParam for NinaLargeArrayParam {
         }
     }
 
-    fn data(&mut self) -> &[u8] {
+    fn data(&self) -> &[u8] {
         self.data.as_slice()
     }
 
-    fn length(self) -> u16 {
+    fn length(&self) -> u16 {
         self.length
     }
 
-    fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
+    fn length_as_bytes(&self) -> Self::LengthAsBytes {
         [
             ((self.length & 0xff00) >> 8) as u8,
             (self.length & 0xff) as u8,

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -1,3 +1,5 @@
+pub mod operation;
+
 use super::*;
 
 use embedded_hal::blocking::delay::DelayMs;
@@ -177,22 +179,6 @@ pub trait ProtocolInterface {
     fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error>;
     fn disconnect(&mut self) -> Result<(), self::Error>;
     fn get_conn_status(&mut self) -> Result<u8, self::Error>;
-
-    fn send_cmd(&mut self, cmd: NinaCommand, num_params: u8) -> Result<(), self::Error>;
-    fn wait_response_cmd(
-        &mut self,
-        cmd: NinaCommand,
-        num_params: u8,
-    ) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], self::Error>;
-    fn send_end_cmd(&mut self) -> Result<(), self::Error>;
-
-    fn get_byte(&mut self) -> Result<u8, self::Error>;
-    fn wait_for_byte(&mut self, wait_byte: u8) -> Result<bool, self::Error>;
-    fn check_start_cmd(&mut self) -> Result<bool, self::Error>;
-    fn read_and_check_byte(&mut self, check_byte: u8) -> Result<bool, self::Error>;
-    fn send_param<P: NinaParam>(&mut self, param: P) -> Result<(), self::Error>;
-    fn send_param_length<P: NinaParam>(&mut self, param: &mut P) -> Result<(), self::Error>;
-    fn pad_to_multiple_of_4(&mut self, command_size: u16);
 }
 
 #[derive(Debug, Default)]

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -27,6 +27,8 @@ pub trait NinaParam {
     fn data(&mut self) -> &[u8];
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes;
+
+    fn length(self) -> u16;
 }
 
 // Used for single byte params
@@ -77,6 +79,10 @@ impl NinaParam for NinaByteParam {
         self.data.as_slice()
     }
 
+    fn length(self) -> u16 {
+        self.length as u16
+    }
+
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
         [self.length as u8]
     }
@@ -104,6 +110,10 @@ impl NinaParam for NinaWordParam {
 
     fn data(&mut self) -> &[u8] {
         self.data.as_slice()
+    }
+
+    fn length(self) -> u16 {
+        self.length as u16
     }
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
@@ -135,6 +145,10 @@ impl NinaParam for NinaSmallArrayParam {
         self.data.as_slice()
     }
 
+    fn length(self) -> u16 {
+        self.length as u16
+    }
+
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {
         [self.length as u8]
     }
@@ -162,6 +176,10 @@ impl NinaParam for NinaLargeArrayParam {
 
     fn data(&mut self) -> &[u8] {
         self.data.as_slice()
+    }
+
+    fn length(self) -> u16 {
+        self.length
     }
 
     fn length_as_bytes(&mut self) -> Self::LengthAsBytes {

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -44,7 +44,7 @@ impl NinaParam for NinaNoParams {
         Self { _placeholder: 0 }
     }
 
-    fn from_bytes(bytes: &[u8]) -> Self {
+    fn from_bytes(_bytes: &[u8]) -> Self {
         Self { _placeholder: 0 }
     }
 

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -40,7 +40,7 @@ pub struct NinaNoParams {
 impl NinaParam for NinaNoParams {
     type LengthAsBytes = [u8; 0];
 
-    fn new(data: &str) -> Self {
+    fn new(_data: &str) -> Self {
         Self { _placeholder: 0 }
     }
 

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -1,4 +1,4 @@
-use super::protocol::{NinaCommand, NinaNoParams, NinaParam};
+use super::protocol::NinaCommand;
 
 use heapless::Vec;
 const MAX_NUMBER_OF_PARAMS: usize = 4;

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -1,26 +1,22 @@
-use super::protocol::{NinaCommand, NinaParam, NinaProtocolHandler, ProtocolInterface};
+use super::protocol::{NinaCommand, NinaParam};
 
 use heapless::Vec;
 const MAX_NUMBER_OF_PARAMS: usize = 4;
-
 pub struct Operation<P> {
-    pub params: Vec<P, MAX_NUMBER_OF_PARAMS>,
+    pub params: Option<Vec<P, MAX_NUMBER_OF_PARAMS>>,
     pub command: NinaCommand,
 }
 
-impl<P> Operation<P>
-where
-    P: NinaParam,
-{
+impl<P> Operation<P> {
     pub fn new(command: NinaCommand) -> Self {
         Self {
-            params: Vec::new(),
+            params: Some(Vec::new()),
             command: command,
         }
     }
 
     pub fn param(mut self, param: P) -> Self {
-        self.params.push(param);
+        self.params.unwrap().push(param);
         self
     }
 }

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -1,0 +1,26 @@
+use super::protocol::{NinaCommand, NinaParam, NinaProtocolHandler, ProtocolInterface};
+
+use heapless::Vec;
+const MAX_NUMBER_OF_PARAMS: usize = 4;
+
+pub struct Operation<P> {
+    params: Vec<P, MAX_NUMBER_OF_PARAMS>,
+    command: NinaCommand,
+}
+
+impl<P> Operation<P>
+where
+    P: NinaParam,
+{
+    pub fn new(command: NinaCommand) -> Self {
+        Self {
+            params: Vec::new(),
+            command: command,
+        }
+    }
+
+    pub fn param(mut self, param: P) -> Self {
+        self.params.push(param);
+        self
+    }
+}

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -1,22 +1,33 @@
-use super::protocol::{NinaCommand, NinaParam};
+use super::protocol::{NinaCommand, NinaNoParams, NinaParam};
 
 use heapless::Vec;
 const MAX_NUMBER_OF_PARAMS: usize = 4;
+
 pub struct Operation<P> {
-    pub params: Option<Vec<P, MAX_NUMBER_OF_PARAMS>>,
+    pub params: Vec<P, MAX_NUMBER_OF_PARAMS>,
     pub command: NinaCommand,
+    pub has_params: bool,
 }
+
+// try ?sized
 
 impl<P> Operation<P> {
     pub fn new(command: NinaCommand) -> Self {
         Self {
-            params: Some(Vec::new()),
+            params: Vec::new(),
             command: command,
+            has_params: true,
         }
     }
 
     pub fn param(mut self, param: P) -> Self {
-        self.params.unwrap().push(param);
+        self.params.push(param);
+        self
+    }
+
+    pub fn with_no_params(mut self, no_param: P) -> Self {
+        self.params.push(no_param);
+        self.has_params = false;
         self
     }
 }

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -26,13 +26,15 @@ impl<P> Operation<P> {
         }
     }
 
-    // Pushes a new param into the internal `params` Vector.
+    // Pushes a new param into the internal `params` Vector which
+    // builds up an internal byte stream representing one Nina command
+    // on the data bus.
     pub fn param(mut self, param: P) -> Self {
         self.params.push(param);
         self
     }
 
-    // Used for denoting an Operation where no params are necessary.
+    // Used for denoting an Operation where no params are provided.
     //
     // Sets `has_params` to `false`
     pub fn with_no_params(mut self, no_param: P) -> Self {

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -3,6 +3,9 @@ use super::protocol::{NinaCommand, NinaNoParams, NinaParam};
 use heapless::Vec;
 const MAX_NUMBER_OF_PARAMS: usize = 4;
 
+// Encapsulates all information needed to execute commands against Nina Firmware.
+// along with user supplied data. Ex. SSID, passphrase, etc.
+
 pub struct Operation<P> {
     pub params: Vec<P, MAX_NUMBER_OF_PARAMS>,
     pub command: NinaCommand,
@@ -11,6 +14,9 @@ pub struct Operation<P> {
 }
 
 impl<P> Operation<P> {
+    // Initializes new Operation instance.
+    //
+    // `has_params` defaults to `true`
     pub fn new(command: NinaCommand, number_of_params_to_receive: u8) -> Self {
         Self {
             params: Vec::new(),
@@ -20,11 +26,15 @@ impl<P> Operation<P> {
         }
     }
 
+    // Pushes a new param into the internal `params` Vector.
     pub fn param(mut self, param: P) -> Self {
         self.params.push(param);
         self
     }
 
+    // Used for denoting an Operation where no params are necessary.
+    //
+    // Sets `has_params` to `false`
     pub fn with_no_params(mut self, no_param: P) -> Self {
         self.params.push(no_param);
         self.has_params = false;

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -7,16 +7,16 @@ pub struct Operation<P> {
     pub params: Vec<P, MAX_NUMBER_OF_PARAMS>,
     pub command: NinaCommand,
     pub has_params: bool,
+    pub number_of_params_to_receive: u8,
 }
 
-// try ?sized
-
 impl<P> Operation<P> {
-    pub fn new(command: NinaCommand) -> Self {
+    pub fn new(command: NinaCommand, number_of_params_to_receive: u8) -> Self {
         Self {
             params: Vec::new(),
             command: command,
             has_params: true,
+            number_of_params_to_receive: number_of_params_to_receive,
         }
     }
 

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -4,8 +4,8 @@ use heapless::Vec;
 const MAX_NUMBER_OF_PARAMS: usize = 4;
 
 pub struct Operation<P> {
-    params: Vec<P, MAX_NUMBER_OF_PARAMS>,
-    command: NinaCommand,
+    pub params: Vec<P, MAX_NUMBER_OF_PARAMS>,
+    pub command: NinaCommand,
 }
 
 impl<P> Operation<P>

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -225,8 +225,8 @@ where
         }
 
         let mut params: [u8; ARRAY_LENGTH_PLACEHOLDER] = [0; 8];
-        for i in 0..num_params_to_read {
-            params[i] = self.get_byte().ok().unwrap()
+        for param in params {
+            params = self.get_byte().ok().unwrap()
         }
         let control_byte: u8 = ControlByte::End as u8;
         self.read_and_check_byte(&control_byte)?;

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -225,8 +225,8 @@ where
         }
 
         let mut params: [u8; ARRAY_LENGTH_PLACEHOLDER] = [0; 8];
-        for param in params {
-            params = self.get_byte().ok().unwrap()
+        for (index, _param) in params.into_iter().enumerate() {
+            params[index] = self.get_byte().ok().unwrap()
         }
         let control_byte: u8 = ControlByte::End as u8;
         self.read_and_check_byte(&control_byte)?;

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -149,7 +149,7 @@ where
         if operation.has_params {
             operation.params.iter().for_each(|param| {
                 self.send_param(param);
-                param_size = param_size + param.length();
+                param_size += param.length();
             });
 
             self.send_end_cmd();

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -5,6 +5,8 @@ use super::protocol::{
     NinaByteParam, NinaCommand, NinaParam, NinaProtocolHandler, NinaSmallArrayParam,
     ProtocolInterface,
 };
+
+use super::protocol::operation::Operation;
 use super::{Error, FirmwareVersion, WifiCommon, ARRAY_LENGTH_PLACEHOLDER};
 
 use embedded_hal::blocking::delay::DelayMs;
@@ -164,7 +166,13 @@ where
 
         Ok(result[0])
     }
+}
 
+impl<S, C> NinaProtocolHandler<S, C>
+where
+    S: Transfer<u8>,
+    C: EspControlInterface,
+{
     fn send_cmd(&mut self, cmd: NinaCommand, num_params: u8) -> Result<(), self::Error> {
         let buf: [u8; 3] = [
             ControlByte::Start as u8,

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -145,7 +145,7 @@ where
 
         self.send_cmd(&operation.command, operation.params.len() as u8);
 
-        // only send params if they are present
+        // Only send params if they are present
         if operation.has_params {
             operation.params.iter().for_each(|param| {
                 self.send_param(param);
@@ -300,7 +300,6 @@ where
         self.send_param_length(param)?;
 
         for byte in param.data().iter() {
-            // TODO: Try using `write_iter`: https://docs.rs/embedded-hal/latest/embedded_hal/blocking/spi/write_iter/index.html
             self.bus.transfer(&mut [byte.clone()]).ok().unwrap();
         }
         Ok(())

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -300,7 +300,7 @@ where
         self.send_param_length(param)?;
 
         for byte in param.data().iter() {
-            self.bus.transfer(&mut [byte.clone()]).ok().unwrap();
+            self.bus.transfer(&mut [*byte]).ok().unwrap();
         }
         Ok(())
     }


### PR DESCRIPTION
## Description

This PR proposes changes to how our low-level `NinaProtocolHandler` struct handles executing commands against Nina firmware on an ESP32 microcontroller.

**The proposed design has one main objective:**
- Create a pattern, in code, which can be employed to quickly and easily implement commands exposed by Nina firmware. 

**The proposed design attempts to achieve (or approximate) the objective by:**
- Pushing as much of the Serial/Control Pin procedural style code as low as possible within the crate's abstraction layers.
- Encapsulating the communication grammar required by Nina firmware in an interface that is both ergonomic to use and, to whatever degree possible, human readable.

#### GitHub Issue: Closes #18 

### Changes
* Adds `operation` module and `operation::Operation` struct
* Adds `protocol::NinaNoParams` struct to use in operations where no params are necessary
* Extracts generic low-level code into generic function `execute` and `receive` which both only require information held in `Operation` struct instances

### Concerns
The concept of `NinaNoParams` is not the prettiest or cleanest way to accomplish the goal of denoting when an `Operation` requires no params. The requirements of `Operation` are such that it was necessary to implement the `NinaParam` trait for `NinaNoParams`. None of the methods required by `NinaParam` are used by `NinaNoParams` and so are dead code. 

This decision was made with the understanding that Rust is hard and that these interfaces will undergo further thought/iteration. 