### PR TITLE
Eliminates all current rustc compile warnings

### DIFF
--- a/cross/get_fw_version/src/main.rs
+++ b/cross/get_fw_version/src/main.rs
@@ -82,9 +82,9 @@ fn main() -> ! {
     defmt::info!("ESP32-WROOM-RP get NINA firmware version example");
 
     // These are implicitly used by the spi driver if they are in the correct mode
-    let spi_miso = pins.gpio16.into_mode::<hal::gpio::FunctionSpi>();
-    let spi_sclk = pins.gpio18.into_mode::<hal::gpio::FunctionSpi>();
-    let spi_mosi = pins.gpio19.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_miso = pins.gpio16.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_sclk = pins.gpio18.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_mosi = pins.gpio19.into_mode::<hal::gpio::FunctionSpi>();
 
     let spi = hal::Spi::<_, _, 8>::new(pac.SPI0);
 

--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -24,13 +24,11 @@ use panic_probe as _;
 // Alias for our HAL crate
 use rp2040_hal as hal;
 
+use embedded_hal::spi::MODE_0;
 use embedded_time::fixed_point::FixedPoint;
 use embedded_time::rate::Extensions;
 use hal::clocks::Clock;
 use hal::pac;
-
-use embedded_hal::spi::MODE_0;
-use embedded_hal::blocking::delay::DelayMs;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -87,9 +85,9 @@ fn main() -> ! {
     defmt::info!("ESP32-WROOM-RP join/leave WiFi network");
 
     // These are implicitly used by the spi driver if they are in the correct mode
-    let spi_miso = pins.gpio16.into_mode::<hal::gpio::FunctionSpi>();
-    let spi_sclk = pins.gpio18.into_mode::<hal::gpio::FunctionSpi>();
-    let spi_mosi = pins.gpio19.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_miso = pins.gpio16.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_sclk = pins.gpio18.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_mosi = pins.gpio19.into_mode::<hal::gpio::FunctionSpi>();
 
     let spi = hal::Spi::<_, _, 8>::new(pac.SPI0);
 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -98,10 +98,12 @@ use embedded_hal::blocking::delay::DelayMs;
 
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 
+/// Highest level error types for this crate.
 #[derive(Debug)]
 pub enum Error {
-    // Placeholder variants
+    /// SPI/I2C related communications error with the ESP32 WiFi target
     Bus,
+    /// Timeout in communicating with the ESP32 WiFi target
     TimeOut,
 }
 

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -98,7 +98,7 @@ impl NinaParam for NinaByteParam {
 
     fn from_bytes(bytes: &[u8]) -> Self {
         let mut data_as_bytes: Vec<u8, 1> = Vec::new();
-        data_as_bytes.extend_from_slice(bytes);
+        data_as_bytes.extend_from_slice(bytes).ok().unwrap();
         Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
@@ -131,7 +131,7 @@ impl NinaParam for NinaWordParam {
 
     fn from_bytes(bytes: &[u8]) -> Self {
         let mut data_as_bytes: Vec<u8, 2> = Vec::new();
-        data_as_bytes.extend_from_slice(bytes);
+        data_as_bytes.extend_from_slice(bytes).ok().unwrap();
         Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
@@ -164,7 +164,7 @@ impl NinaParam for NinaSmallArrayParam {
 
     fn from_bytes(bytes: &[u8]) -> Self {
         let mut data_as_bytes: Vec<u8, MAX_NINA_PARAM_LENGTH> = Vec::new();
-        data_as_bytes.extend_from_slice(bytes);
+        data_as_bytes.extend_from_slice(bytes).ok().unwrap();
         Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
@@ -197,7 +197,7 @@ impl NinaParam for NinaLargeArrayParam {
 
     fn from_bytes(bytes: &[u8]) -> Self {
         let mut data_as_bytes: Vec<u8, MAX_NINA_PARAM_LENGTH> = Vec::new();
-        data_as_bytes.extend_from_slice(bytes);
+        data_as_bytes.extend_from_slice(bytes).ok().unwrap();
         Self {
             length: data_as_bytes.len() as u16,
             data: data_as_bytes,

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -30,7 +30,7 @@ impl<P> Operation<P> {
     // builds up an internal byte stream representing one Nina command
     // on the data bus.
     pub fn param(mut self, param: P) -> Self {
-        self.params.push(param);
+        self.params.push(param).ok().unwrap();
         self
     }
 
@@ -38,7 +38,7 @@ impl<P> Operation<P> {
     //
     // Sets `has_params` to `false`
     pub fn with_no_params(mut self, no_param: P) -> Self {
-        self.params.push(no_param);
+        self.params.push(no_param).ok().unwrap();
         self.has_params = false;
         self
     }

--- a/host-tests/tests/spi.rs
+++ b/host-tests/tests/spi.rs
@@ -1,4 +1,2 @@
-use std::{thread, time::Duration};
-
 #[test]
 fn do_something_with_spi_succeeds() {}


### PR DESCRIPTION

## Description
This PR eliminates all current compile warnings and missing documentation warnings.


#### GitHub Issue: Closes #23 

### Changes
* Eliminates all rustc compiler warnings
* Adds all missing documentation for public modules, structs and enums

### Testing Strategy
Build all parts of the project (see README.md for instructions) and observe no warnings.


### Concerns
N/A