### PR TITLE
fix number_of_params issue

### DIFF
--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -70,7 +70,7 @@ where
     }
 
     /// Retrieves the current WiFi network connection status.
-    /// 
+    ///
     /// NOTE: A future version will provide a enumerated type instead of the raw integer values
     /// from the NINA firmware.
     pub fn get_connection_status(&mut self) -> Result<u8, Error> {
@@ -147,8 +147,14 @@ where
     fn execute<P: NinaParam>(&mut self, operation: &Operation<P>) -> Result<(), Error> {
         let mut param_size: u16 = 0;
         self.control_pins.wait_for_esp_select();
-
-        self.send_cmd(&operation.command, operation.params.len() as u8).ok().unwrap();
+        let number_of_params: u8 = if operation.has_params {
+            operation.params.len() as u8
+        } else {
+            0
+        };
+        self.send_cmd(&operation.command, number_of_params)
+            .ok()
+            .unwrap();
 
         // Only send params if they are present
         if operation.has_params {


### PR DESCRIPTION
## Description
This PR fixes an issue that was causing our examples to fail.

This issue was one where we were passing the wrong number of parameters for the NINA firmware to expect.

#### GitHub Issue: _link your GitHub issue here_

### Changes
* Fix number of params issue
### Testing Strategy
```Rust
caleb@calebs-MacBook-Pro cross % cargo run --bin join                      
   Compiling esp32-wroom-rp v0.1.0 (/Users/caleb/Desktop/edge/esp32-wroom-rp/esp32-wroom-rp)
   Compiling join v0.1.0 (/Users/caleb/Desktop/edge/esp32-wroom-rp/cross/join)
    Finished dev [optimized + debuginfo] target(s) in 3.05s
     Running `probe-run --chip RP2040 target/thumbv6m-none-eabi/debug/join`
(HOST) INFO  flashing program (4 pages / 16.00 KiB)
(HOST) INFO  success!
────────────────────────────────────────────────────────────────────────────────
INFO  ESP32-WROOM-RP join/leave WiFi network
└─ join::__cortex_m_rt_main @ join/src/main.rs:82
INFO  Join Result: Ok(())
└─ join::__cortex_m_rt_main @ join/src/main.rs:112
INFO  Entering main loop
└─ join::__cortex_m_rt_main @ join/src/main.rs:114
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ join/src/main.rs:119
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ join/src/main.rs:119
INFO  Get Connection Result: 1
└─ join::__cortex_m_rt_main @ join/src/main.rs:119
INFO  Get Connection Result: 3
└─ join::__cortex_m_rt_main @ join/src/main.rs:119
INFO  Connected to Network: "Calebphone"
```
