### PR TITLE
Refactor error handling

### DIFF
--- a/cross/get_fw_version/src/main.rs
+++ b/cross/get_fw_version/src/main.rs
@@ -63,10 +63,7 @@ fn main() -> ! {
     .ok()
     .unwrap();
 
-    let mut delay = cortex_m::delay::Delay::new(
-        core.SYST,
-        clocks.system_clock.freq().integer(),
-    );
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
 
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);

--- a/cross/get_fw_version/src/main.rs
+++ b/cross/get_fw_version/src/main.rs
@@ -86,14 +86,14 @@ fn main() -> ! {
     let spi = hal::Spi::<_, _, 8>::new(pac.SPI0);
 
     // Exchange the uninitialized SPI driver for an initialized one
-    let spi = spi.init(
+    let mut spi = spi.init(
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
         8_000_000u32.Hz(),
         &MODE_0,
     );
 
-    let esp_pins = esp32_wroom_rp::gpio::EspControlPins {
+    let mut esp_pins = esp32_wroom_rp::gpio::EspControlPins {
         // CS on pin x (GPIO7)
         cs: pins.gpio7.into_mode::<hal::gpio::PushPullOutput>(),
         // GPIO0 on pin x (GPIO2)
@@ -103,7 +103,7 @@ fn main() -> ! {
         // ACK on pin x (GPIO10)
         ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
     };
-    let mut wifi = esp32_wroom_rp::wifi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
+    let mut wifi = esp32_wroom_rp::wifi::Wifi::init(&mut spi, &mut esp_pins, &mut delay).unwrap();
     let firmware_version = wifi.firmware_version();
     defmt::info!("NINA firmware version: {:?}", firmware_version);
 

--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -66,10 +66,7 @@ fn main() -> ! {
     .ok()
     .unwrap();
 
-    let mut delay = cortex_m::delay::Delay::new(
-        core.SYST,
-        clocks.system_clock.freq().integer(),
-    );
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
 
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);

--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -89,14 +89,14 @@ fn main() -> ! {
     let spi = hal::Spi::<_, _, 8>::new(pac.SPI0);
 
     // Exchange the uninitialized SPI driver for an initialized one
-    let spi = spi.init(
+    let mut spi = spi.init(
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
         8_000_000u32.Hz(),
         &MODE_0,
     );
 
-    let esp_pins = esp32_wroom_rp::gpio::EspControlPins {
+    let mut esp_pins = esp32_wroom_rp::gpio::EspControlPins {
         // CS on pin x (GPIO7)
         cs: pins.gpio7.into_mode::<hal::gpio::PushPullOutput>(),
         // GPIO0 on pin x (GPIO2)
@@ -107,7 +107,8 @@ fn main() -> ! {
         ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
     };
 
-    let mut wifi = esp32_wroom_rp::wifi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
+    let mut wifi = esp32_wroom_rp::wifi::Wifi::init(&mut spi, &mut esp_pins, &mut delay).unwrap();
+
     let result = wifi.join(SSID, PASSPHRASE);
     defmt::info!("Join Result: {:?}", result);
 

--- a/esp32-wroom-rp/src/gpio.rs
+++ b/esp32-wroom-rp/src/gpio.rs
@@ -41,7 +41,7 @@ enum IOError {
 
 /// Provides an internal pin interface that abstracts the extra control lines that
 /// are separate from a data bus (e.g. SPI/I2C).
-/// 
+///
 /// Not meant to be used outside of the crate.
 pub trait EspControlInterface {
     /// Initializes all controls pins to set ready communication with the NINA firmware.
@@ -98,27 +98,27 @@ where
 {
     fn init(&mut self) {
         // Chip select is active-low, so we'll initialize it to a driven-high state
-        self.cs.set_high().ok().unwrap();
-        self.gpio0.set_high().ok().unwrap();
-        self.resetn.set_high().ok().unwrap();
+        self.cs.set_high().ok();
+        self.gpio0.set_high().ok();
+        self.resetn.set_high().ok();
         self.get_esp_ready();
     }
 
     fn reset<D: DelayMs<u16>>(&mut self, delay: &mut D) {
-        self.gpio0.set_high().ok().unwrap();
-        self.cs.set_high().ok().unwrap();
-        self.resetn.set_low().ok().unwrap();
+        self.gpio0.set_high().ok();
+        self.cs.set_high().ok();
+        self.resetn.set_low().ok();
         delay.delay_ms(10);
-        self.resetn.set_high().ok().unwrap();
+        self.resetn.set_high().ok();
         delay.delay_ms(750);
     }
 
     fn esp_select(&mut self) {
-        self.cs.set_low().ok().unwrap();
+        self.cs.set_low().ok();
     }
 
     fn esp_deselect(&mut self) {
-        self.cs.set_high().ok().unwrap();
+        self.cs.set_high().ok();
     }
 
     fn get_esp_ready(&self) -> bool {

--- a/esp32-wroom-rp/src/gpio.rs
+++ b/esp32-wroom-rp/src/gpio.rs
@@ -154,7 +154,7 @@ impl Default for EspControlPins<(), (), (), ()> {
             cs: (),
             gpio0: (),
             resetn: (),
-            ack: ()
+            ack: (),
         }
     }
 }

--- a/esp32-wroom-rp/src/gpio.rs
+++ b/esp32-wroom-rp/src/gpio.rs
@@ -75,7 +75,7 @@ pub trait EspControlInterface {
 /// A structured representation of all GPIO pins that control a ESP32-WROOM NINA firmware-based
 /// device outside of commands sent over the SPI/I²C bus. Pass a single instance of this struct
 /// into `Wifi::init()`.
-pub struct EspControlPins<CS: OutputPin, GPIO0: OutputPin, RESETN: OutputPin, ACK: InputPin> {
+pub struct EspControlPins<CS, GPIO0, RESETN, ACK> {
     /// Chip select pin to let the NINA firmware know we're going to send it a command over
     /// the SPI bus.
     pub cs: CS,
@@ -131,13 +131,13 @@ where
 
     fn wait_for_esp_ready(&self) {
         while self.get_esp_ready() != true {
-            cortex_m::asm::nop(); // Make sure rustc doesn't optimize this loop out
+            //cortex_m::asm::nop(); // Make sure rustc doesn't optimize this loop out
         }
     }
 
     fn wait_for_esp_ack(&self) {
         while self.get_esp_ack() == false {
-            cortex_m::asm::nop(); // Make sure rustc doesn't optimize this loop out
+            //cortex_m::asm::nop(); // Make sure rustc doesn't optimize this loop out
         }
     }
 
@@ -145,6 +145,17 @@ where
         self.wait_for_esp_ready();
         self.esp_select();
         self.wait_for_esp_ack();
+    }
+}
+
+impl Default for EspControlPins<(), (), (), ()> {
+    fn default() -> Self {
+        Self {
+            cs: (),
+            gpio0: (),
+            resetn: (),
+            ack: ()
+        }
     }
 }
 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -91,7 +91,7 @@ pub mod wifi;
 pub mod protocol;
 mod spi;
 
-use protocol::{ProtocolInterface, ProtocolError};
+use protocol::{ProtocolError, ProtocolInterface};
 
 use defmt::{write, Format, Formatter};
 use embedded_hal::blocking::delay::DelayMs;
@@ -111,7 +111,11 @@ impl Format for Error {
     fn format(&self, fmt: Formatter) {
         match self {
             Error::Bus => write!(fmt, "Bus error"),
-            Error::Protocol(e) => write!(fmt, "Communication protocol error with ESP32 WiFi target: {}", e),
+            Error::Protocol(e) => write!(
+                fmt,
+                "Communication protocol error with ESP32 WiFi target: {}",
+                e
+            ),
         }
     }
 }

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -75,7 +75,7 @@
 //!     ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
 //! };
 //!
-//! let mut wifi = esp32_wroom_rp::spi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
+//! let mut wifi = esp32_wroom_rp::spi::Wifi::init(&mut spi, &mut esp_pins, &mut delay).unwrap();
 //! let version = wifi.firmware_version();
 //! ```
 
@@ -88,7 +88,7 @@ pub mod gpio;
 /// Fundamental interface for controlling a connected ESP32-WROOM NINA firmware-based Wifi board.
 pub mod wifi;
 
-mod protocol;
+pub mod protocol;
 mod spi;
 
 use protocol::{ProtocolInterface, ProtocolError};
@@ -99,7 +99,7 @@ use embedded_hal::blocking::delay::DelayMs;
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 
 /// Highest level error types for this crate.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// SPI/I2C related communications error with the ESP32 WiFi target
     Bus,
@@ -118,13 +118,7 @@ impl Format for Error {
 
 impl From<protocol::ProtocolError> for Error {
     fn from(err: protocol::ProtocolError) -> Self {
-        match err {
-            protocol::ProtocolError::CommunicationTimeout => Error::Protocol(err),
-            protocol::ProtocolError::InvalidCommand => Error::Protocol(err),
-            protocol::ProtocolError::InvalidNumberOfParameters => Error::Protocol(err),
-            protocol::ProtocolError::NinaProtocolVersionMismatch => Error::Protocol(err),
-            protocol::ProtocolError::TooManyParameters => Error::Protocol(err),
-        }
+        Error::Protocol(err)
     }
 }
 
@@ -167,7 +161,7 @@ impl Format for FirmwareVersion {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct WifiCommon<PH> {
     protocol_handler: PH,
 }

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -236,3 +236,8 @@ pub(crate) struct NinaProtocolHandler<B, C> {
     /// An EspControlPins instance
     pub control_pins: C,
 }
+
+pub(crate) enum Error {
+    NinaProtocolVersionMismatch,
+    Timeout,
+}

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -245,7 +245,7 @@ pub enum ProtocolError {
     CommunicationTimeout,
     InvalidCommand,
     InvalidNumberOfParameters,
-    TooManyParameters
+    TooManyParameters,
 }
 
 impl Format for ProtocolError {

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -1,4 +1,4 @@
-pub mod operation;
+pub(crate) mod operation;
 
 use super::*;
 
@@ -8,7 +8,7 @@ use defmt::{write, Format, Formatter};
 
 use heapless::{String, Vec};
 
-pub const MAX_NINA_PARAM_LENGTH: usize = 255;
+pub(crate) const MAX_NINA_PARAM_LENGTH: usize = 255;
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
@@ -231,15 +231,15 @@ pub(crate) trait ProtocolInterface {
     fn get_conn_status(&mut self) -> Result<u8, ProtocolError>;
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct NinaProtocolHandler<B, C> {
+#[derive(Debug)]
+pub(crate) struct NinaProtocolHandler<'a, B, C> {
     /// A Spi or I2c instance
-    pub bus: B,
+    pub bus: &'a mut B,
     /// An EspControlPins instance
-    pub control_pins: C,
+    pub control_pins: &'a mut C,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ProtocolError {
     NinaProtocolVersionMismatch,
     CommunicationTimeout,

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -239,6 +239,8 @@ pub(crate) struct NinaProtocolHandler<'a, B, C> {
     pub control_pins: &'a mut C,
 }
 
+// TODO: look at Nina Firmware code to understand conditions
+// that lead to NinaProtocolVersionMismatch
 #[derive(Debug, PartialEq)]
 pub enum ProtocolError {
     NinaProtocolVersionMismatch,

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -15,6 +15,9 @@ use embedded_hal::blocking::spi::Transfer;
 
 use core::convert::Infallible;
 
+// FIXME: remove before commit
+//use defmt_rtt as _;
+
 // TODO: this should eventually move into NinaCommandHandler
 #[repr(u8)]
 #[derive(Debug)]
@@ -199,8 +202,6 @@ where
 
         for byte in buf {
             let write_buf = &mut [byte];
-            // FIXME: temporary for test writing debugging
-            defmt::debug!("0x{:02x}, ", write_buf[0]);
             self.bus.transfer(write_buf).ok();
         }
 

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -7,7 +7,7 @@ use super::protocol::{
 };
 
 use super::protocol::operation::Operation;
-use super::protocol::Error as ProtocolError;
+use super::protocol::ProtocolError;
 use super::{Error, FirmwareVersion, WifiCommon, ARRAY_LENGTH_PLACEHOLDER};
 
 use embedded_hal::blocking::delay::DelayMs;
@@ -93,22 +93,22 @@ where
     }
 
     fn reset<D: DelayMs<u16>>(&mut self, delay: &mut D) {
-        self.control_pins.reset(delay)
+        self.control_pins.reset(delay);
     }
 
-    fn get_fw_version(&mut self) -> Result<FirmwareVersion, self::Error> {
+    fn get_fw_version(&mut self) -> Result<FirmwareVersion, ProtocolError> {
         // TODO: improve the ergonomics around with_no_params()
         let operation =
             Operation::new(NinaCommand::GetFwVersion, 1).with_no_params(NinaNoParams::new(""));
 
-        self.execute(&operation).ok().unwrap();
+        self.execute(&operation)?;
 
         let result = self.receive(&operation)?;
 
         Ok(FirmwareVersion::new(result)) // e.g. 1.7.4
     }
 
-    fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), self::Error> {
+    fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), ProtocolError> {
         let operation = Operation::new(NinaCommand::SetPassphrase, 1)
             .param(NinaSmallArrayParam::new(ssid))
             .param(NinaSmallArrayParam::new(passphrase));
@@ -119,7 +119,7 @@ where
         Ok(())
     }
 
-    fn get_conn_status(&mut self) -> Result<u8, self::Error> {
+    fn get_conn_status(&mut self) -> Result<u8, ProtocolError> {
         let operation =
             Operation::new(NinaCommand::GetConnStatus, 1).with_no_params(NinaNoParams::new(""));
 
@@ -130,7 +130,7 @@ where
         Ok(result[0])
     }
 
-    fn disconnect(&mut self) -> Result<(), self::Error> {
+    fn disconnect(&mut self) -> Result<(), ProtocolError> {
         let dummy_param = NinaByteParam::from_bytes(&[ControlByte::Dummy as u8]);
         let operation = Operation::new(NinaCommand::Disconnect, 1).param(dummy_param);
 
@@ -147,7 +147,7 @@ where
     S: Transfer<u8>,
     C: EspControlInterface,
 {
-    fn execute<P: NinaParam>(&mut self, operation: &Operation<P>) -> Result<(), Error> {
+    fn execute<P: NinaParam>(&mut self, operation: &Operation<P>) -> Result<(), ProtocolError> {
         let mut param_size: u16 = 0;
         self.control_pins.wait_for_esp_select();
         let number_of_params: u8 = if operation.has_params {
@@ -155,18 +155,16 @@ where
         } else {
             0
         };
-        self.send_cmd(&operation.command, number_of_params)
-            .ok()
-            .unwrap();
+        let result = self.send_cmd(&operation.command, number_of_params);
 
         // Only send params if they are present
         if operation.has_params {
             operation.params.iter().for_each(|param| {
-                self.send_param(param).ok().unwrap();
+                self.send_param(param).ok();
                 param_size += param.length();
             });
 
-            self.send_end_cmd().ok().unwrap();
+            self.send_end_cmd().ok();
 
             // This is to make sure we align correctly
             // 4 (start byte, command byte, reply byte, end byte) + the sum of all param lengths
@@ -175,13 +173,13 @@ where
         }
         self.control_pins.esp_deselect();
 
-        Ok(())
+        result
     }
 
     fn receive<P: NinaParam>(
         &mut self,
         operation: &Operation<P>,
-    ) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], Error> {
+    ) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], ProtocolError> {
         self.control_pins.wait_for_esp_select();
 
         let result =
@@ -192,7 +190,7 @@ where
         result
     }
 
-    fn send_cmd(&mut self, cmd: &NinaCommand, num_params: u8) -> Result<(), self::Error> {
+    fn send_cmd(&mut self, cmd: &NinaCommand, num_params: u8) -> Result<(), ProtocolError> {
         let buf: [u8; 3] = [
             ControlByte::Start as u8,
             (*cmd as u8) & !(ControlByte::Reply as u8),
@@ -201,11 +199,11 @@ where
 
         for byte in buf {
             let write_buf = &mut [byte];
-            self.bus.transfer(write_buf).ok().unwrap();
+            self.bus.transfer(write_buf).ok();
         }
 
         if num_params == 0 {
-            self.send_end_cmd().ok().unwrap();
+            self.send_end_cmd().ok();
         }
         Ok(())
     }
@@ -214,28 +212,26 @@ where
         &mut self,
         cmd: &NinaCommand,
         num_params: u8,
-    ) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], self::Error> {
+    ) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], ProtocolError> {
         self.check_start_cmd().ok().unwrap();
         let byte_to_check: u8 = *cmd as u8 | ControlByte::Reply as u8;
-        let result = self.read_and_check_byte(&byte_to_check)?;
+        let result = self.read_and_check_byte(&byte_to_check).ok().unwrap();
         // Ensure we see a cmd byte
         if !result {
-            return Ok([0x31, 0x2e, 0x37, 0x2e, 0x34, 0x0, 0x0, 0x0]);
-            //return Err(SPIError::Misc);
+            return Err(ProtocolError::InvalidCommand);
         }
 
-        let result = self.read_and_check_byte(&num_params)?;
+        let result = self.read_and_check_byte(&num_params).unwrap();
         // Ensure we see the number of params we expected to receive back
         if !result {
-            return Ok([0x31, 0x2e, 0x37, 0x2e, 0x34, 0x0, 0x0, 0x0]);
-            //return Err(SPIError::Misc);
+            return Err(ProtocolError::InvalidNumberOfParameters);
         }
 
-        let num_params_to_read = self.get_byte()? as usize;
+        let num_params_to_read = self.get_byte().ok().unwrap() as usize;
 
+        // TODO: use a constant instead of inline params max == 8
         if num_params_to_read > 8 {
-            return Ok([0x31, 0x2e, 0x37, 0x2e, 0x34, 0x0, 0x0, 0x0]);
-            //return Err(SPIError::Misc);
+            return Err(ProtocolError::TooManyParameters);
         }
 
         let mut params: [u8; ARRAY_LENGTH_PLACEHOLDER] = [0; 8];
@@ -243,14 +239,14 @@ where
             params[index] = self.get_byte().ok().unwrap()
         }
         let control_byte: u8 = ControlByte::End as u8;
-        self.read_and_check_byte(&control_byte)?;
+        self.read_and_check_byte(&control_byte).ok();
 
         Ok(params)
     }
 
-    fn send_end_cmd(&mut self) -> Result<(), self::Error> {
+    fn send_end_cmd(&mut self) -> Result<(), Infallible> {
         let end_command: &mut [u8] = &mut [ControlByte::End as u8];
-        self.bus.transfer(end_command).ok().unwrap();
+        self.bus.transfer(end_command).ok();
         Ok(())
     }
 
@@ -271,58 +267,38 @@ where
                 return Ok(true);
             }
         }
-        Err(ProtocolError::Timeout)
+        Err(ProtocolError::CommunicationTimeout)
     }
 
-    fn check_start_cmd(&mut self) -> Result<bool, self::Error> {
+    fn check_start_cmd(&mut self) -> Result<bool, ProtocolError> {
         self.wait_for_byte(ControlByte::Start as u8)
     }
 
-    fn read_and_check_byte(&mut self, check_byte: &u8) -> Result<bool, self::Error> {
-        match self.get_byte() {
-            Ok(byte_out) => {
-                // Question: does comparing two &u8s work the way we would think?
-                return Ok(&byte_out == check_byte);
-            }
-            Err(e) => {
-                return Err(e);
-            }
-        }
+    fn read_and_check_byte(&mut self, check_byte: &u8) -> Result<bool, Infallible> {
+        let byte = self.get_byte().ok().unwrap();
+        Ok(&byte == check_byte)
     }
 
-    fn send_param<P: NinaParam>(&mut self, param: &P) -> Result<(), self::Error> {
+    fn send_param<P: NinaParam>(&mut self, param: &P) -> Result<(), Infallible> {
         self.send_param_length(param)?;
 
         for byte in param.data().iter() {
-            self.bus.transfer(&mut [*byte]).ok().unwrap();
+            self.bus.transfer(&mut [*byte]).ok();
         }
         Ok(())
     }
 
-    fn send_param_length<P: NinaParam>(&mut self, param: &P) -> Result<(), self::Error> {
+    fn send_param_length<P: NinaParam>(&mut self, param: &P) -> Result<(), Infallible> {
         for byte in param.length_as_bytes().into_iter() {
-            self.bus.transfer(&mut [byte]).ok().unwrap();
+            self.bus.transfer(&mut [byte]).ok();
         }
         Ok(())
     }
 
     fn pad_to_multiple_of_4(&mut self, mut command_size: u16) {
         while command_size % 4 == 0 {
-            self.get_byte().ok().unwrap();
+            self.get_byte().ok();
             command_size += 1;
         }
     }
-}
-
-#[allow(dead_code)]
-/// Error which occurred during a SPI transaction with a target ESP32 device
-#[derive(Clone, Copy, Debug)]
-pub enum SPIError<SPIE, IOE> {
-    /// The SPI implementation returned an error
-    SPI(SPIE),
-    /// The GPIO implementation returned an error when changing the chip-select pin state
-    IO(IOE),
-    /// Timeout
-    Timeout,
-    Misc,
 }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -113,9 +113,9 @@ where
             .param(NinaSmallArrayParam::new(ssid))
             .param(NinaSmallArrayParam::new(passphrase));
 
-        self.execute(&operation).ok().unwrap();
+        self.execute(&operation)?;
 
-        self.receive(&operation).ok().unwrap();
+        self.receive(&operation)?;
         Ok(())
     }
 
@@ -123,7 +123,7 @@ where
         let operation =
             Operation::new(NinaCommand::GetConnStatus, 1).with_no_params(NinaNoParams::new(""));
 
-        self.execute(&operation).ok().unwrap();
+        self.execute(&operation)?;
 
         let result = self.receive(&operation)?;
 
@@ -134,9 +134,9 @@ where
         let dummy_param = NinaByteParam::from_bytes(&[ControlByte::Dummy as u8]);
         let operation = Operation::new(NinaCommand::Disconnect, 1).param(dummy_param);
 
-        self.execute(&operation).ok().unwrap();
+        self.execute(&operation)?;
 
-        self.receive(&operation).ok().unwrap();
+        self.receive(&operation)?;
 
         Ok(())
     }

--- a/host-tests/Cargo.toml
+++ b/host-tests/Cargo.toml
@@ -12,3 +12,4 @@ description = "Host-side tests for the Rust-based Espressif ESP32-WROOM WiFi dri
 
 [dev-dependencies]
 embedded-hal-mock = "0.8.0"
+esp32-wroom-rp = { path = "../esp32-wroom-rp" }

--- a/host-tests/tests/spi.rs
+++ b/host-tests/tests/spi.rs
@@ -1,11 +1,9 @@
-use embedded_hal_mock::spi;
-use embedded_hal_mock::pin::{
-    Mock as PinMock, State as PinState, Transaction as PinTransaction,
-};
 use embedded_hal_mock::delay::MockNoop;
+use embedded_hal_mock::pin::{Mock as PinMock, State as PinState, Transaction as PinTransaction};
+use embedded_hal_mock::spi;
 
-use esp32_wroom_rp::wifi::Wifi;
 use esp32_wroom_rp::gpio::EspControlInterface;
+use esp32_wroom_rp::wifi::Wifi;
 
 struct EspControlMock {}
 
@@ -18,7 +16,7 @@ impl EspControlInterface for EspControlMock {
         true
     }
 
-   fn  wait_for_esp_select(&mut self) {}
+    fn wait_for_esp_select(&mut self) {}
 
     fn wait_for_esp_ack(&self) {}
 
@@ -41,7 +39,6 @@ fn invalid_command_induces_nina_protocol_version_mismatch_error() {
         spi::Transaction::transfer(vec![0x37], vec![0x0]),
         spi::Transaction::transfer(vec![0x0], vec![0x0]),
         spi::Transaction::transfer(vec![0xee], vec![0x0]),
-
         // wait_response_cmd()
         spi::Transaction::transfer(vec![0xff], vec![0xef]),
     ];
@@ -54,7 +51,12 @@ fn invalid_command_induces_nina_protocol_version_mismatch_error() {
     let mut wifi = Wifi::init(&mut spi, &mut pins, &mut delay).ok().unwrap();
     let f = wifi.firmware_version();
 
-    assert_eq!(f.unwrap_err(), esp32_wroom_rp::Error::Protocol(esp32_wroom_rp::protocol::ProtocolError::NinaProtocolVersionMismatch));
+    assert_eq!(
+        f.unwrap_err(),
+        esp32_wroom_rp::Error::Protocol(
+            esp32_wroom_rp::protocol::ProtocolError::NinaProtocolVersionMismatch
+        )
+    );
 
     spi.done();
 }

--- a/host-tests/tests/spi.rs
+++ b/host-tests/tests/spi.rs
@@ -1,2 +1,60 @@
+use embedded_hal_mock::spi;
+use embedded_hal_mock::pin::{
+    Mock as PinMock, State as PinState, Transaction as PinTransaction,
+};
+use embedded_hal_mock::delay::MockNoop;
+
+use esp32_wroom_rp::wifi::Wifi;
+use esp32_wroom_rp::gpio::EspControlInterface;
+
+struct EspControlMock {}
+
+impl EspControlInterface for EspControlMock {
+    fn init(&mut self) {}
+
+    fn reset<D>(&mut self, _delay: &mut D) {}
+
+    fn get_esp_ack(&self) -> bool {
+        true
+    }
+
+   fn  wait_for_esp_select(&mut self) {}
+
+    fn wait_for_esp_ack(&self) {}
+
+    fn wait_for_esp_ready(&self) {}
+
+    fn esp_select(&mut self) {}
+
+    fn esp_deselect(&mut self) {}
+
+    fn get_esp_ready(&self) -> bool {
+        true
+    }
+}
+
 #[test]
-fn do_something_with_spi_succeeds() {}
+fn invalid_command_induces_nina_protocol_version_mismatch_error() {
+    let spi_expectations = vec![
+        // send_cmd()
+        spi::Transaction::transfer(vec![0xe0], vec![0x0]),
+        spi::Transaction::transfer(vec![0x37], vec![0x0]),
+        spi::Transaction::transfer(vec![0x0], vec![0x0]),
+        spi::Transaction::transfer(vec![0xee], vec![0x0]),
+
+        // wait_response_cmd()
+        spi::Transaction::transfer(vec![0xff], vec![0xef]),
+    ];
+    let mut spi = spi::Mock::new(&spi_expectations);
+
+    let mut delay = MockNoop::new();
+
+    let mut pins = EspControlMock {};
+
+    let mut wifi = Wifi::init(&mut spi, &mut pins, &mut delay).ok().unwrap();
+    let f = wifi.firmware_version();
+
+    assert_eq!(f.unwrap_err(), esp32_wroom_rp::Error::Protocol(esp32_wroom_rp::protocol::ProtocolError::NinaProtocolVersionMismatch));
+
+    spi.done();
+}

--- a/host-tests/tests/spi.rs
+++ b/host-tests/tests/spi.rs
@@ -1,5 +1,4 @@
 use embedded_hal_mock::delay::MockNoop;
-use embedded_hal_mock::pin::{Mock as PinMock, State as PinState, Transaction as PinTransaction};
 use embedded_hal_mock::spi;
 
 use esp32_wroom_rp::gpio::EspControlInterface;
@@ -29,6 +28,134 @@ impl EspControlInterface for EspControlMock {
     fn get_esp_ready(&self) -> bool {
         true
     }
+}
+
+#[test]
+fn too_many_parameters_error() {
+    let spi_expectations = vec![
+        // send_cmd()
+        spi::Transaction::transfer(vec![0xe0], vec![0x0]),
+        spi::Transaction::transfer(vec![0x37], vec![0x0]),
+        spi::Transaction::transfer(vec![0x0], vec![0x0]),
+        spi::Transaction::transfer(vec![0xee], vec![0x0]),
+        // wait_response_cmd()
+        spi::Transaction::transfer(vec![0xff], vec![0xe0]),
+        spi::Transaction::transfer(vec![0xff], vec![0xb7]),
+        spi::Transaction::transfer(vec![0xff], vec![0x1]),
+        // test relies on max number of parameters being 8. This will probably change
+        // as we understand more.
+        spi::Transaction::transfer(vec![0xff], vec![0x9]),
+    ];
+    let mut spi = spi::Mock::new(&spi_expectations);
+
+    let mut delay = MockNoop::new();
+
+    let mut pins = EspControlMock {};
+
+    let mut wifi = Wifi::init(&mut spi, &mut pins, &mut delay).ok().unwrap();
+    let f = wifi.firmware_version();
+
+    assert_eq!(
+        f.unwrap_err(),
+        esp32_wroom_rp::Error::Protocol(esp32_wroom_rp::protocol::ProtocolError::TooManyParameters)
+    );
+
+    spi.done();
+}
+
+#[test]
+fn invalid_number_of_parameters_error() {
+    let spi_expectations = vec![
+        // send_cmd()
+        spi::Transaction::transfer(vec![0xe0], vec![0x0]),
+        spi::Transaction::transfer(vec![0x37], vec![0x0]),
+        spi::Transaction::transfer(vec![0x0], vec![0x0]),
+        spi::Transaction::transfer(vec![0xee], vec![0x0]),
+        // wait_response_cmd()
+        spi::Transaction::transfer(vec![0xff], vec![0xe0]),
+        spi::Transaction::transfer(vec![0xff], vec![0xb7]),
+        spi::Transaction::transfer(vec![0xff], vec![0x0]),
+    ];
+    let mut spi = spi::Mock::new(&spi_expectations);
+
+    let mut delay = MockNoop::new();
+
+    let mut pins = EspControlMock {};
+
+    let mut wifi = Wifi::init(&mut spi, &mut pins, &mut delay).ok().unwrap();
+    let f = wifi.firmware_version();
+
+    assert_eq!(
+        f.unwrap_err(),
+        esp32_wroom_rp::Error::Protocol(
+            esp32_wroom_rp::protocol::ProtocolError::InvalidNumberOfParameters
+        )
+    );
+
+    spi.done();
+}
+
+#[test]
+fn invalid_command_induces_invalid_command_error() {
+    let spi_expectations = vec![
+        // send_cmd()
+        spi::Transaction::transfer(vec![0xe0], vec![0x0]),
+        spi::Transaction::transfer(vec![0x37], vec![0x0]),
+        spi::Transaction::transfer(vec![0x0], vec![0x0]),
+        spi::Transaction::transfer(vec![0xee], vec![0x0]),
+        // wait_response_cmd()
+        spi::Transaction::transfer(vec![0xff], vec![0xe0]),
+        spi::Transaction::transfer(vec![0xff], vec![0x0]),
+    ];
+    let mut spi = spi::Mock::new(&spi_expectations);
+
+    let mut delay = MockNoop::new();
+
+    let mut pins = EspControlMock {};
+
+    let mut wifi = Wifi::init(&mut spi, &mut pins, &mut delay).ok().unwrap();
+    let f = wifi.firmware_version();
+
+    assert_eq!(
+        f.unwrap_err(),
+        esp32_wroom_rp::Error::Protocol(esp32_wroom_rp::protocol::ProtocolError::InvalidCommand)
+    );
+
+    spi.done();
+}
+
+#[test]
+fn timeout_induces_communication_timeout_error() {
+    let mut spi_expectations = vec![
+        // send_cmd()
+        spi::Transaction::transfer(vec![0xe0], vec![0x0]),
+        spi::Transaction::transfer(vec![0x37], vec![0x0]),
+        spi::Transaction::transfer(vec![0x0], vec![0x0]),
+        spi::Transaction::transfer(vec![0xee], vec![0x0]),
+    ];
+
+    // simulate reading 1000 bytes which will exhaust the retry limit.
+    for _ in 0..1000 {
+        spi_expectations.push(spi::Transaction::transfer(vec![0xff], vec![0x0]))
+    }
+
+    let mut spi = spi::Mock::new(&spi_expectations);
+
+    let mut delay = MockNoop::new();
+
+    let mut pins = EspControlMock {};
+
+    let mut wifi = Wifi::init(&mut spi, &mut pins, &mut delay).ok().unwrap();
+    let f = wifi.firmware_version();
+
+    assert_eq!(
+        f.unwrap_err(),
+        esp32_wroom_rp::Error::Protocol(
+            esp32_wroom_rp::protocol::ProtocolError::CommunicationTimeout
+        )
+    );
+
+    spi.done();
 }
 
 #[test]


### PR DESCRIPTION
## Description
Provides a flexible-enough and increasingly mature implementation of error types and error handling across the entire crate.

#### GitHub Issue: Closes #21 

### Changes
* Adds `protocol::ProtocolError` as a public error type for use in `NinaProtocolHandler` and consumption by users of this crate via `Error(ProtocolError)`
* Adds host-side integration tests that induce all of the `ProtocolError` errors
* Refactors the public interface `WiFi` to accept mutable references to `Spi` and `EspControlPin` instances to avoid taking over ownership of these two instances (discovered by writing integration tests against this interface)

### Testing Strategy
```sh
cd host-tests
cargo test # <-- ensure that all tests pass
```

### Concerns
* Cannot verify our public documentation via `cargo doc` due to [this issue](https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues/34)