### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,40 @@
+name: Bug Report
+description: File a bug report for esp32-wroom-rp
+title: "[Bug]: "
+labels: ["bug", "triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the issue here.
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: input
+    id: hardware
+    attributes:
+      label: What is the exact model of RP2040 hardware you are seeing the problem on?
+      placeholder: ex. Raspberry Pi Pico, Adafruit Feather RP2040, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Any related code to produce this issue.
+      description: Please copy and paste any relevant code to re-produce this issue. If you have your own public repository, you can link to that here. 
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,19 @@
+name: Feature request
+description: Suggest an feature / idea for this project
+title: "[Feature Request / Suggestion]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We appreciate your feedback on how to improve this project. Please be sure to include as much details & any resources as possible!
+  - type: textarea
+    id: Suggestion
+    attributes:
+      label: Suggestion / Feature Request
+      description: Describe the feature(s) you would like to see added.
+      placeholder: Tell us your suggestion
+      value: "Your suggestion here"
+    validations:
+      required: true
+ 


### PR DESCRIPTION
## Description
Adds GitHub issue templates for submitting a bug and for requesting a feature.

#### GitHub Issue: N/A

### Changes
* Adds a GitHub issue template for submitting a bug
* Adds a GitHub issue template for requesting a new feature

### Testing Strategy
Once merged you'll be able to navigate to the new [Issue form for the project](https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues/new/choose), observe that you can choose from the templates. Until then, just click "..." and "View file" for each of the yaml files in the review section to get a rich sense for what they'll look like once merged.


### Concerns
None