### PR TITLE
Address all known static analysis security issues and Clippy warnings

### DIFF
--- a/cross/get_fw_version/Cargo.toml
+++ b/cross/get_fw_version/Cargo.toml
@@ -17,17 +17,17 @@ doctest = false
 test = false
 
 [dependencies]
-defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+defmt = "0.3"
+defmt-rtt = "0.3"
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 embedded-hal = { version = "0.2", features=["unproven"] }
-embedded-time = "0.12"
 esp32-wroom-rp = { path = "../../esp32-wroom-rp" }
 panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 
-rp2040-hal = { version = "0.5", features=["rt", "eh1_0_alpha"] }
+rp2040-hal = { version = "0.6", features=["rt", "eh1_0_alpha"] }
 rp2040-boot2 = { version = "0.2" }
+fugit = "0.3"
 
 [features]
 default = ['defmt-default']

--- a/cross/get_fw_version/src/main.rs
+++ b/cross/get_fw_version/src/main.rs
@@ -22,8 +22,7 @@ use panic_probe as _;
 use rp2040_hal as hal;
 
 use embedded_hal::spi::MODE_0;
-use embedded_time::fixed_point::FixedPoint;
-use embedded_time::rate::Extensions;
+use fugit::RateExtU32;
 use hal::clocks::Clock;
 use hal::pac;
 
@@ -63,7 +62,7 @@ fn main() -> ! {
     .ok()
     .unwrap();
 
-    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
 
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);
@@ -89,7 +88,7 @@ fn main() -> ! {
     let mut spi = spi.init(
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
-        8_000_000u32.Hz(),
+        8.MHz(),
         &MODE_0,
     );
 

--- a/cross/join/Cargo.toml
+++ b/cross/join/Cargo.toml
@@ -17,17 +17,17 @@ doctest = false
 test = false
 
 [dependencies]
-defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+defmt = "0.3"
+defmt-rtt = "0.3"
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 embedded-hal = { version = "0.2", features=["unproven"] }
-embedded-time = "0.12"
 esp32-wroom-rp = { path = "../../esp32-wroom-rp" }
 panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 
-rp2040-hal = { version = "0.5", features=["rt", "eh1_0_alpha"] }
+rp2040-hal = { version = "0.6", features=["rt", "eh1_0_alpha"] }
 rp2040-boot2 = { version = "0.2" }
+fugit = "0.3"
 
 [features]
 default = ['defmt-default']

--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -25,8 +25,7 @@ use panic_probe as _;
 use rp2040_hal as hal;
 
 use embedded_hal::spi::MODE_0;
-use embedded_time::fixed_point::FixedPoint;
-use embedded_time::rate::Extensions;
+use fugit::RateExtU32;
 use hal::clocks::Clock;
 use hal::pac;
 
@@ -66,7 +65,7 @@ fn main() -> ! {
     .ok()
     .unwrap();
 
-    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
 
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);
@@ -92,7 +91,7 @@ fn main() -> ! {
     let mut spi = spi.init(
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
-        8_000_000u32.Hz(),
+        8.MHz(),
         &MODE_0,
     );
 

--- a/esp32-wroom-rp/Cargo.toml
+++ b/esp32-wroom-rp/Cargo.toml
@@ -2,12 +2,13 @@
 authors = [
     "Jim Hodapp",
     "Caleb Bourg",
-    "Glyn Matthews"
+    "Glyn Matthews",
+    "Dilyn Corner"
 ]
 edition = "2021"
 readme = "README.md"
 name = "esp32-wroom-rp"
-version = "0.1.0"
+version = "0.3.0"
 description = "Rust-based Espressif ESP32-WROOM WiFi driver crate for RP2040 series microcontroller boards."
 
 [lib]
@@ -21,7 +22,6 @@ cortex-m = "0.7"
 cortex-m-rt = "0.7"
 cortex-m-semihosting = "0.5"
 embedded-hal = { version = "0.2", features=["unproven"] }
-embedded-time = "0.12"
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/esp32-wroom-rp/src/gpio.rs
+++ b/esp32-wroom-rp/src/gpio.rs
@@ -130,13 +130,13 @@ where
     }
 
     fn wait_for_esp_ready(&self) {
-        while self.get_esp_ready() != true {
+        while !self.get_esp_ready() {
             //cortex_m::asm::nop(); // Make sure rustc doesn't optimize this loop out
         }
     }
 
     fn wait_for_esp_ack(&self) {
-        while self.get_esp_ack() == false {
+        while !self.get_esp_ack() {
             //cortex_m::asm::nop(); // Make sure rustc doesn't optimize this loop out
         }
     }

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -99,7 +99,7 @@ use embedded_hal::blocking::delay::DelayMs;
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 
 /// Highest level error types for this crate.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     /// SPI/I2C related communications error with the ESP32 WiFi target
     Bus,
@@ -127,7 +127,7 @@ impl From<protocol::ProtocolError> for Error {
 }
 
 /// A structured representation of a connected NINA firmware device's version number (e.g. 1.7.4).
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct FirmwareVersion {
     major: u8,
     minor: u8,

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! esp32_wroom_rp = 0.1
+//! esp32_wroom_rp = 0.3
 //! ```
 //!
 //! Next:
@@ -60,7 +60,7 @@
 //! let spi = spi.init(
 //!     &mut pac.RESETS,
 //!     clocks.peripheral_clock.freq(),
-//!     8_000_000u32.Hz(),
+//!     8.MHz(),
 //!     &MODE_0,
 //! );
 //!

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -141,16 +141,16 @@ impl FirmwareVersion {
 
     // Takes in 8 bytes (e.g. 1.7.4) and returns a FirmwareVersion instance
     fn parse(version: [u8; ARRAY_LENGTH_PLACEHOLDER]) -> FirmwareVersion {
-        let major: u8;
-        let minor: u8;
-        let patch: u8;
+        let major_version: u8;
+        let minor_version: u8;
+        let patch_version: u8;
 
-        [major, _, minor, _, patch, _, _, _] = version;
+        [major_version, _, minor_version, _, patch_version, _, _, _] = version;
 
         FirmwareVersion {
-            major: major,
-            minor: minor,
-            patch: patch,
+            major: major_version,
+            minor: minor_version,
+            patch: patch_version,
         }
     }
 }

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -241,7 +241,7 @@ pub(crate) struct NinaProtocolHandler<'a, B, C> {
 
 // TODO: look at Nina Firmware code to understand conditions
 // that lead to NinaProtocolVersionMismatch
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ProtocolError {
     NinaProtocolVersionMismatch,
     CommunicationTimeout,

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -241,7 +241,7 @@ pub(crate) struct NinaProtocolHandler<'a, B, C> {
 
 // TODO: look at Nina Firmware code to understand conditions
 // that lead to NinaProtocolVersionMismatch
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ProtocolError {
     NinaProtocolVersionMismatch,
     CommunicationTimeout,

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -17,12 +17,12 @@ impl<P> Operation<P> {
     // Initializes new Operation instance.
     //
     // `has_params` defaults to `true`
-    pub fn new(command: NinaCommand, number_of_params_to_receive: u8) -> Self {
+    pub fn new(nina_command: NinaCommand, number_of_nina_params_to_receive: u8) -> Self {
         Self {
             params: Vec::new(),
-            command: command,
+            command: nina_command,
             has_params: true,
-            number_of_params_to_receive: number_of_params_to_receive,
+            number_of_params_to_receive: number_of_nina_params_to_receive,
         }
     }
 

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -44,14 +44,14 @@ where
     /// Calling this function puts the connected ESP32-WROOM device in a known good state to accept commands.
     pub fn init<D: DelayMs<u16>>(
         spi: &'a mut S,
-        control_pins: &'a mut C,
+        esp32_control_pins: &'a mut C,
         delay: &mut D,
     ) -> Result<Wifi<'a, S, C>, Error> {
         let mut wifi = Wifi {
             common: WifiCommon {
                 protocol_handler: NinaProtocolHandler {
                     bus: spi,
-                    control_pins: control_pins,
+                    control_pins: esp32_control_pins,
                 },
             },
         };


### PR DESCRIPTION
## Description
This PR addresses all known static analysis security issues and Clippy warnings.


#### GitHub Issue: Fixes #41 

### Changes
* Addresses all known static analysis security issues and [Clippy warnings](https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/security/code-scanning)
* Upgrades all crate dependencies to latest stable versions

### Testing Strategy

1. Check to see if Clippy has any more warnings after GitHub Actions CI runs the code scanner.
2. Run all examples under cross/
3. Run all host-side tests


### Concerns
**Note** there are several interface/API documentation warnings that are unaddressed here but are fully addressed by the [branch which adds DNS resolve support](https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/tree/support_dns).