### PR TITLE
Support DNS

### DIFF
--- a/cross/Cargo.toml
+++ b/cross/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "get_fw_version",
   "join",
+  "dns"
 ]
 
 [profile.dev]

--- a/cross/dns/Cargo.toml
+++ b/cross/dns/Cargo.toml
@@ -22,12 +22,12 @@ defmt-rtt = "0.3.0"
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 embedded-hal = { version = "0.2", features=["unproven"] }
-embedded-time = "0.12"
 esp32-wroom-rp = { path = "../../esp32-wroom-rp" }
 panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 
-rp2040-hal = { version = "0.5", features=["rt", "eh1_0_alpha"] }
+rp2040-hal = { version = "0.6", features=["rt", "eh1_0_alpha"] }
 rp2040-boot2 = { version = "0.2" }
+fugit = "0.3"
 
 [features]
 default = ['defmt-default']

--- a/cross/dns/Cargo.toml
+++ b/cross/dns/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+authors = [
+    "Jim Hodapp",
+    "Caleb Bourg",
+    "Glyn Matthews"
+]
+edition = "2021"
+name = "dns"
+version = "0.1.0"
+description = "Example target application that demonstrates DNS functionality with the Rust-based Espressif ESP32-WROOM WiFi driver crate for RP2040 series microcontroller boards."
+
+# makes `cargo check --all-targets` work
+[[bin]]
+name = "dns"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+embedded-hal = { version = "0.2", features=["unproven"] }
+embedded-time = "0.12"
+esp32-wroom-rp = { path = "../../esp32-wroom-rp" }
+panic-probe = { version = "0.3.0", features = ["print-rtt"] }
+
+rp2040-hal = { version = "0.5", features=["rt", "eh1_0_alpha"] }
+rp2040-boot2 = { version = "0.2" }
+
+[features]
+default = ['defmt-default']
+# these features are required by defmt
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -1,8 +1,7 @@
 //! # ESP32-WROOM-RP Pico Wireless Example
 //!
-//! This application demonstrates how to use the ESP32-WROOM-RP crate to request that
-//! a remote ESP32 WiFi target connects to a particular SSID given a passphrase
-//! and then leaves (disconnects) that same network.
+//! This application demonstrates how to use the ESP32-WROOM-RP crate to perform
+//! a DNS hostname lookup after setting what DNS server to use.
 //!
 //! See the `Cargo.toml` file for Copyright and license details.
 
@@ -126,15 +125,23 @@ fn main() -> ! {
                 if byte == 3 {
                     defmt::info!("Connected to Network: {:?}", SSID);
 
-                    let ip1: IpAddress = [10, 0, 1, 3];
-                    let dns_result = wifi.set_dns(ip1, None);
+                    // The IPAddress of our DNS server to resolve hostnames with
+                    let ip1: IpAddress = [9, 9, 9, 9];
+                    let ip2: IpAddress = [8, 8, 8, 8];
+                    let dns_result = wifi.set_dns(ip1, Some(ip2));
 
                     defmt::info!("set_dns result: {:?}", dns_result);
 
-                    defmt::info!("Doing a DNS resolve for thecitybase.com");
+                    let hostname = "thecitybase.com";
+                    defmt::info!("Doing a DNS resolve for {}", hostname);
 
-                    let ip = wifi.resolve("thecitybase.com");
-                    defmt::info!("Server IP: {:?}", ip);
+                    match wifi.resolve(hostname) {
+                        Ok(ip) => { defmt::info!("Server IP: {:?}", ip); }
+                        Err(e) => {
+                            defmt::error!("Failed to resolve hostname {}", hostname);
+                            defmt::error!("Err: {}", e);
+                        }
+                    }
 
                     wifi.leave().ok().unwrap();
                 } else if byte == 6 {

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -136,7 +136,9 @@ fn main() -> ! {
                     defmt::info!("Doing a DNS resolve for {}", hostname);
 
                     match wifi.resolve(hostname) {
-                        Ok(ip) => { defmt::info!("Server IP: {:?}", ip); }
+                        Ok(ip) => {
+                            defmt::info!("Server IP: {:?}", ip);
+                        }
                         Err(e) => {
                             defmt::error!("Failed to resolve hostname {}", hostname);
                             defmt::error!("Err: {}", e);

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -131,9 +131,9 @@ fn main() -> ! {
 
                     defmt::info!("set_dns result: {:?}", dns_result);
 
-                    defmt::info!("Doing a DNS resolve for ambi.matrix.net");
+                    defmt::info!("Doing a DNS resolve for thecitybase.com");
 
-                    let ip = wifi.resolve("ambi.matrix.net");
+                    let ip = wifi.resolve("thecitybase.com");
                     defmt::info!("Server IP: {:?}", ip);
 
                     wifi.leave().ok().unwrap();

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -24,8 +24,7 @@ use panic_probe as _;
 use rp2040_hal as hal;
 
 use embedded_hal::spi::MODE_0;
-use embedded_time::fixed_point::FixedPoint;
-use embedded_time::rate::Extensions;
+use fugit::RateExtU32;
 use hal::clocks::Clock;
 use hal::pac;
 
@@ -67,7 +66,7 @@ fn main() -> ! {
     .ok()
     .unwrap();
 
-    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
 
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);
@@ -93,7 +92,7 @@ fn main() -> ! {
     let mut spi = spi.init(
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
-        8_000_000u32.Hz(),
+        8.MHz(),
         &MODE_0,
     );
 

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -124,7 +124,8 @@ fn main() -> ! {
                 if byte == 3 {
                     defmt::info!("Connected to Network: {:?}", SSID);
 
-                    // The IPAddress of our DNS server to resolve hostnames with
+                    // The IPAddresses of two DNS servers to resolve hostnames with.
+                    // Note that failover from ip1 to ip2 is fully functional.
                     let ip1: IpAddress = [9, 9, 9, 9];
                     let ip2: IpAddress = [8, 8, 8, 8];
                     let dns_result = wifi.set_dns(ip1, Some(ip2));

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -28,7 +28,7 @@ use fugit::RateExtU32;
 use hal::clocks::Clock;
 use hal::pac;
 
-use esp32_wroom_rp::IpAddress;
+use esp32_wroom_rp::network::IpAddress;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -79,7 +79,7 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    defmt::info!("ESP32-WROOM-RP join/leave WiFi network");
+    defmt::info!("ESP32-WROOM-RP DNS resolve example");
 
     // These are implicitly used by the spi driver if they are in the correct mode
     let _spi_miso = pins.gpio16.into_mode::<hal::gpio::FunctionSpi>();

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -126,13 +126,15 @@ fn main() -> ! {
                 if byte == 3 {
                     defmt::info!("Connected to Network: {:?}", SSID);
 
-                    let ip1: IpAddress = [9, 9, 9, 9];
+                    let ip1: IpAddress = [10, 0, 1, 3];
                     let dns_result = wifi.set_dns(ip1, None);
 
                     defmt::info!("set_dns result: {:?}", dns_result);
 
-                    defmt::info!("Sleeping for 5 seconds before disconnecting...");
-                    delay.delay_ms(5000);
+                    defmt::info!("Doing a DNS resolve for ambi.matrix.net");
+
+                    let ip = wifi.resolve("ambi.matrix.net");
+                    defmt::info!("Server IP: {:?}", ip);
 
                     wifi.leave().ok().unwrap();
                 } else if byte == 6 {

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -1,0 +1,147 @@
+//! # ESP32-WROOM-RP Pico Wireless Example
+//!
+//! This application demonstrates how to use the ESP32-WROOM-RP crate to request that
+//! a remote ESP32 WiFi target connects to a particular SSID given a passphrase
+//! and then leaves (disconnects) that same network.
+//!
+//! See the `Cargo.toml` file for Copyright and license details.
+
+#![no_std]
+#![no_main]
+
+extern crate esp32_wroom_rp;
+
+include!("secrets/secrets.rs");
+
+// The macro for our start-up function
+use cortex_m_rt::entry;
+
+// Needed for debug output symbols to be linked in binary image
+use defmt_rtt as _;
+
+use panic_probe as _;
+
+// Alias for our HAL crate
+use rp2040_hal as hal;
+
+use embedded_hal::spi::MODE_0;
+use embedded_time::fixed_point::FixedPoint;
+use embedded_time::rate::Extensions;
+use hal::clocks::Clock;
+use hal::pac;
+
+use esp32_wroom_rp::IpAddress;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+/// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
+/// if your board has a different frequency
+const XTAL_FREQ_HZ: u32 = 12_000_000u32;
+
+/// Entry point to our bare-metal application.
+///
+/// The `#[entry]` macro ensures the Cortex-M start-up code calls this function
+/// as soon as all global variables are initialized.
+#[entry]
+fn main() -> ! {
+    // Grab our singleton objects
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    // Set up the watchdog driver - needed by the clock setup code
+    let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+
+    // Configure the clocks
+    let clocks = hal::clocks::init_clocks_and_plls(
+        XTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+
+    // The single-cycle I/O block controls our GPIO pins
+    let sio = hal::Sio::new(pac.SIO);
+
+    // Set the pins to their default state
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    defmt::info!("ESP32-WROOM-RP join/leave WiFi network");
+
+    // These are implicitly used by the spi driver if they are in the correct mode
+    let _spi_miso = pins.gpio16.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_sclk = pins.gpio18.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_mosi = pins.gpio19.into_mode::<hal::gpio::FunctionSpi>();
+
+    let spi = hal::Spi::<_, _, 8>::new(pac.SPI0);
+
+    // Exchange the uninitialized SPI driver for an initialized one
+    let mut spi = spi.init(
+        &mut pac.RESETS,
+        clocks.peripheral_clock.freq(),
+        8_000_000u32.Hz(),
+        &MODE_0,
+    );
+
+    let mut esp_pins = esp32_wroom_rp::gpio::EspControlPins {
+        // CS on pin x (GPIO7)
+        cs: pins.gpio7.into_mode::<hal::gpio::PushPullOutput>(),
+        // GPIO0 on pin x (GPIO2)
+        gpio0: pins.gpio2.into_mode::<hal::gpio::PushPullOutput>(),
+        // RESETn on pin x (GPIO11)
+        resetn: pins.gpio11.into_mode::<hal::gpio::PushPullOutput>(),
+        // ACK on pin x (GPIO10)
+        ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
+    };
+
+    let mut wifi = esp32_wroom_rp::wifi::Wifi::init(&mut spi, &mut esp_pins, &mut delay).unwrap();
+
+    let result = wifi.join(SSID, PASSPHRASE);
+    defmt::info!("Join Result: {:?}", result);
+
+    defmt::info!("Entering main loop");
+
+    loop {
+        match wifi.get_connection_status() {
+            Ok(byte) => {
+                defmt::info!("Get Connection Result: {:?}", byte);
+                let sleep: u32 = 1500;
+                delay.delay_ms(sleep);
+
+                if byte == 3 {
+                    defmt::info!("Connected to Network: {:?}", SSID);
+
+                    let ip1: IpAddress = [9, 9, 9, 9];
+                    let dns_result = wifi.set_dns(ip1, None);
+
+                    defmt::info!("set_dns result: {:?}", dns_result);
+
+                    defmt::info!("Sleeping for 5 seconds before disconnecting...");
+                    delay.delay_ms(5000);
+
+                    wifi.leave().ok().unwrap();
+                } else if byte == 6 {
+                    defmt::info!("Disconnected from Network: {:?}", SSID);
+                }
+            }
+            Err(e) => {
+                defmt::info!("Failed to Get Connection Result: {:?}", e);
+            }
+        }
+    }
+}

--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> ! {
 
                     defmt::info!("set_dns result: {:?}", dns_result);
 
-                    let hostname = "thecitybase.com";
+                    let hostname = "github.com";
                     defmt::info!("Doing a DNS resolve for {}", hostname);
 
                     match wifi.resolve(hostname) {

--- a/cross/dns/src/secrets/secrets.rs
+++ b/cross/dns/src/secrets/secrets.rs
@@ -1,0 +1,7 @@
+//
+// secrets.rs - stores WiFi secrets like SSID, passphrase, etc shared across
+//              all example applications
+//
+
+const SSID: &str = "ssid";
+const PASSPHRASE: &str = "passphrase";

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -202,27 +202,27 @@ where
     }
 
     fn firmware_version(&mut self) -> Result<FirmwareVersion, Error> {
-        Ok(self.protocol_handler.get_fw_version()?)
+        self.protocol_handler.get_fw_version()
     }
 
     fn join(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error> {
-        Ok(self.protocol_handler.set_passphrase(ssid, passphrase)?)
+        self.protocol_handler.set_passphrase(ssid, passphrase)
     }
 
     fn leave(&mut self) -> Result<(), Error> {
-        Ok(self.protocol_handler.disconnect()?)
+        self.protocol_handler.disconnect()
     }
 
     fn get_connection_status(&mut self) -> Result<u8, Error> {
-        Ok(self.protocol_handler.get_conn_status()?)
+        self.protocol_handler.get_conn_status()
     }
 
     fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), Error> {
-        Ok(self.protocol_handler.set_dns_config(dns1, dns2)?)
+        self.protocol_handler.set_dns_config(dns1, dns2)
     }
 
     fn resolve(&mut self, hostname: &str) -> Result<IpAddress, Error> {
-        Ok(self.protocol_handler.resolve(hostname)?)
+        self.protocol_handler.resolve(hostname)
     }
 }
 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -88,7 +88,9 @@ pub mod gpio;
 /// Fundamental interface for controlling a connected ESP32-WROOM NINA firmware-based Wifi board.
 pub mod wifi;
 
+/// Responsible for interactions over a WiFi network.
 pub mod network;
+/// Responsible for interactions with NINA firmware over a data bus.
 pub mod protocol;
 
 mod spi;
@@ -101,6 +103,7 @@ use embedded_hal::blocking::delay::DelayMs;
 
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 
+/// A four byte array type alias representing an IP address.
 pub type IpAddress = [u8; 4];
 
 /// Highest level error types for this crate.

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -202,7 +202,7 @@ where
     }
 
     fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), Error> {
-        Ok(self.protocol_handler.set_dns(dns1, dns2)?)
+        Ok(self.protocol_handler.set_dns_config(dns1, dns2)?)
     }
 
     fn resolve(&mut self, hostname: &str) -> Result<IpAddress, Error> {

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -88,7 +88,7 @@ pub mod gpio;
 /// Fundamental interface for controlling a connected ESP32-WROOM NINA firmware-based Wifi board.
 pub mod wifi;
 
-/// Responsible for interactions over a WiFi network.
+/// Responsible for interactions over a WiFi network and also contains related types.
 pub mod network;
 /// Responsible for interactions with NINA firmware over a data bus.
 pub mod protocol;

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -95,16 +95,13 @@ pub mod protocol;
 
 mod spi;
 
-use network::NetworkError;
+use network::{IpAddress, NetworkError};
 use protocol::{ProtocolError, ProtocolInterface};
 
 use defmt::{write, Format, Formatter};
 use embedded_hal::blocking::delay::DelayMs;
 
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
-
-/// A four byte array type alias representing an IP address.
-pub type IpAddress = [u8; 4];
 
 /// Highest level error types for this crate.
 #[derive(Debug, Eq, PartialEq)]

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -201,8 +201,12 @@ where
         Ok(self.protocol_handler.get_conn_status()?)
     }
 
-    fn set_dns(&mut self, ip1: IpAddress, ip2: Option<IpAddress>) -> Result<(), Error> {
-        Ok(self.protocol_handler.set_dns(ip1, ip2)?)
+    fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), Error> {
+        Ok(self.protocol_handler.set_dns(dns1, dns2)?)
+    }
+
+    fn resolve(&mut self, hostname: &str) -> Result<IpAddress, Error> {
+        Ok(self.protocol_handler.resolve(hostname)?)
     }
 }
 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -98,6 +98,8 @@ use embedded_hal::blocking::delay::DelayMs;
 
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 
+pub type IpAddress = [u8; 4];
+
 /// Highest level error types for this crate.
 #[derive(Debug, Eq, PartialEq)]
 pub enum Error {
@@ -197,6 +199,10 @@ where
 
     fn get_connection_status(&mut self) -> Result<u8, Error> {
         Ok(self.protocol_handler.get_conn_status()?)
+    }
+
+    fn set_dns(&mut self, ip1: IpAddress, ip2: Option<IpAddress>) -> Result<(), Error> {
+        Ok(self.protocol_handler.set_dns(ip1, ip2)?)
     }
 }
 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -88,9 +88,12 @@ pub mod gpio;
 /// Fundamental interface for controlling a connected ESP32-WROOM NINA firmware-based Wifi board.
 pub mod wifi;
 
+pub mod network;
 pub mod protocol;
+
 mod spi;
 
+use network::NetworkError;
 use protocol::{ProtocolError, ProtocolInterface};
 
 use defmt::{write, Format, Formatter};
@@ -107,6 +110,9 @@ pub enum Error {
     Bus,
     /// Protocol error in communicating with the ESP32 WiFi target
     Protocol(ProtocolError),
+
+    /// Network related error
+    Network(NetworkError),
 }
 
 impl Format for Error {
@@ -118,6 +124,7 @@ impl Format for Error {
                 "Communication protocol error with ESP32 WiFi target: {}",
                 e
             ),
+            Error::Network(e) => write!(fmt, "Network error: {}", e),
         }
     }
 }
@@ -125,6 +132,12 @@ impl Format for Error {
 impl From<protocol::ProtocolError> for Error {
     fn from(err: protocol::ProtocolError) -> Self {
         Error::Protocol(err)
+    }
+}
+
+impl From<network::NetworkError> for Error {
+    fn from(err: network::NetworkError) -> Self {
+        Error::Network(err)
     }
 }
 

--- a/esp32-wroom-rp/src/network.rs
+++ b/esp32-wroom-rp/src/network.rs
@@ -1,0 +1,16 @@
+use defmt::{write, Format, Formatter};
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum NetworkError {
+    DnsResolveFailed,
+}
+
+impl Format for NetworkError {
+    fn format(&self, fmt: Formatter) {
+        match self {
+            NetworkError::DnsResolveFailed => {
+                write!(fmt, "Failed when trying to resolve a DNS hostname")
+            }
+        }
+    }
+}

--- a/esp32-wroom-rp/src/network.rs
+++ b/esp32-wroom-rp/src/network.rs
@@ -1,5 +1,8 @@
 use defmt::{write, Format, Formatter};
 
+/// A four byte array type alias representing an IP address.
+pub type IpAddress = [u8; 4];
+
 /// Errors that occur due to issues involving communication over
 /// WiFi network.
 #[derive(PartialEq, Eq, Debug)]

--- a/esp32-wroom-rp/src/network.rs
+++ b/esp32-wroom-rp/src/network.rs
@@ -7,7 +7,7 @@ pub type IpAddress = [u8; 4];
 /// WiFi network.
 #[derive(PartialEq, Eq, Debug)]
 pub enum NetworkError {
-    /// Failure to resolve a hostname to an IP address.
+    /// Failed to resolve a hostname for the provided IP address.
     DnsResolveFailed,
 }
 

--- a/esp32-wroom-rp/src/network.rs
+++ b/esp32-wroom-rp/src/network.rs
@@ -15,7 +15,7 @@ impl Format for NetworkError {
     fn format(&self, fmt: Formatter) {
         match self {
             NetworkError::DnsResolveFailed => {
-                write!(fmt, "Failed when trying to resolve a DNS hostname")
+                write!(fmt, "Failed to resolve a hostname for the provided IP address")
             }
         }
     }

--- a/esp32-wroom-rp/src/network.rs
+++ b/esp32-wroom-rp/src/network.rs
@@ -1,7 +1,10 @@
 use defmt::{write, Format, Formatter};
 
+/// Errors that occur due to issues involving communication over
+/// WiFi network.
 #[derive(PartialEq, Eq, Debug)]
 pub enum NetworkError {
+    /// Failure to resolve a hostname to an IP address.
     DnsResolveFailed,
 }
 

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -232,7 +232,11 @@ pub(crate) trait ProtocolInterface {
     fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), ProtocolError>;
     fn disconnect(&mut self) -> Result<(), ProtocolError>;
     fn get_conn_status(&mut self) -> Result<u8, ProtocolError>;
-    fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), ProtocolError>;
+    fn set_dns_config(
+        &mut self,
+        dns1: IpAddress,
+        dns2: Option<IpAddress>,
+    ) -> Result<(), ProtocolError>;
     fn req_host_by_name(&mut self, hostname: &str) -> Result<u8, ProtocolError>;
     fn get_host_by_name(&mut self) -> Result<[u8; 8], ProtocolError>;
     fn resolve(&mut self, hostname: &str) -> Result<IpAddress, ProtocolError>;

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -228,18 +228,14 @@ impl NinaParam for NinaLargeArrayParam {
 pub(crate) trait ProtocolInterface {
     fn init(&mut self);
     fn reset<D: DelayMs<u16>>(&mut self, delay: &mut D);
-    fn get_fw_version(&mut self) -> Result<FirmwareVersion, ProtocolError>;
-    fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), ProtocolError>;
-    fn disconnect(&mut self) -> Result<(), ProtocolError>;
-    fn get_conn_status(&mut self) -> Result<u8, ProtocolError>;
-    fn set_dns_config(
-        &mut self,
-        dns1: IpAddress,
-        dns2: Option<IpAddress>,
-    ) -> Result<(), ProtocolError>;
-    fn req_host_by_name(&mut self, hostname: &str) -> Result<u8, ProtocolError>;
-    fn get_host_by_name(&mut self) -> Result<[u8; 8], ProtocolError>;
-    fn resolve(&mut self, hostname: &str) -> Result<IpAddress, ProtocolError>;
+    fn get_fw_version(&mut self) -> Result<FirmwareVersion, Error>;
+    fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error>;
+    fn disconnect(&mut self) -> Result<(), Error>;
+    fn get_conn_status(&mut self) -> Result<u8, Error>;
+    fn set_dns_config(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), Error>;
+    fn req_host_by_name(&mut self, hostname: &str) -> Result<u8, Error>;
+    fn get_host_by_name(&mut self) -> Result<[u8; 8], Error>;
+    fn resolve(&mut self, hostname: &str) -> Result<IpAddress, Error>;
 }
 
 #[derive(Debug)]
@@ -259,8 +255,6 @@ pub enum ProtocolError {
     InvalidCommand,
     InvalidNumberOfParameters,
     TooManyParameters,
-
-    DnsResolveFailed,
 }
 
 impl Format for ProtocolError {
@@ -270,9 +264,7 @@ impl Format for ProtocolError {
             ProtocolError::CommunicationTimeout => write!(fmt, "Communication with ESP32 target timed out."),
             ProtocolError::InvalidCommand => write!(fmt, "Encountered an invalid command while communicating with ESP32 target."),
             ProtocolError::InvalidNumberOfParameters => write!(fmt, "Encountered an unexpected number of parameters for a NINA command while communicating with ESP32 target."),
-            ProtocolError::TooManyParameters => write!(fmt, "Encountered too many parameters for a NINA command while communicating with ESP32 target."),
-
-            ProtocolError::DnsResolveFailed => write!(fmt, "Failed when trying to resolve a DNS hostname"),
+            ProtocolError::TooManyParameters => write!(fmt, "Encountered too many parameters for a NINA command while communicating with ESP32 target.")
         }
     }
 }

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -259,7 +259,7 @@ pub enum ProtocolError {
     InvalidCommand,
     InvalidNumberOfParameters,
     TooManyParameters,
-    
+
     DnsResolveFailed,
 }
 

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -259,6 +259,8 @@ pub enum ProtocolError {
     InvalidCommand,
     InvalidNumberOfParameters,
     TooManyParameters,
+    
+    DnsResolveFailed,
 }
 
 impl Format for ProtocolError {
@@ -269,6 +271,8 @@ impl Format for ProtocolError {
             ProtocolError::InvalidCommand => write!(fmt, "Encountered an invalid command while communicating with ESP32 target."),
             ProtocolError::InvalidNumberOfParameters => write!(fmt, "Encountered an unexpected number of parameters for a NINA command while communicating with ESP32 target."),
             ProtocolError::TooManyParameters => write!(fmt, "Encountered too many parameters for a NINA command while communicating with ESP32 target."),
+
+            ProtocolError::DnsResolveFailed => write!(fmt, "Failed when trying to resolve a DNS hostname"),
         }
     }
 }

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -17,6 +17,7 @@ pub(crate) enum NinaCommand {
     SetPassphrase = 0x11u8,
     GetConnStatus = 0x20u8,
     Disconnect = 0x30u8,
+    SetDNSConfig = 0x15u8,
 }
 
 pub(crate) trait NinaParam {
@@ -229,6 +230,7 @@ pub(crate) trait ProtocolInterface {
     fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), ProtocolError>;
     fn disconnect(&mut self) -> Result<(), ProtocolError>;
     fn get_conn_status(&mut self) -> Result<u8, ProtocolError>;
+    fn set_dns(&mut self, ip1: IpAddress, ip2: Option<IpAddress>) -> Result<(), ProtocolError>;
 }
 
 #[derive(Debug)]

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -248,12 +248,19 @@ pub(crate) struct NinaProtocolHandler<'a, B, C> {
 
 // TODO: look at Nina Firmware code to understand conditions
 // that lead to NinaProtocolVersionMismatch
+/// Errors related to communication with NINA firmware
 #[derive(Debug, Eq, PartialEq)]
 pub enum ProtocolError {
+    /// TODO: look at Nina Firmware code to understand conditions
+    /// that lead to NinaProtocolVersionMismatch
     NinaProtocolVersionMismatch,
+    /// A timeout occurred.
     CommunicationTimeout,
+    /// An invalid NINA command has been sent over the data bus.
     InvalidCommand,
+    /// An invalid number of parameters sent over the data bus.
     InvalidNumberOfParameters,
+    /// Too many parameters sent over the data bus.
     TooManyParameters,
 }
 

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -18,7 +18,8 @@ pub(crate) enum NinaCommand {
     GetConnStatus = 0x20u8,
     Disconnect = 0x30u8,
     SetDNSConfig = 0x15u8,
-    GetHostByName = 0x35u8
+    ReqHostByName = 0x34u8,
+    GetHostByName = 0x35u8,
 }
 
 pub(crate) trait NinaParam {
@@ -232,6 +233,8 @@ pub(crate) trait ProtocolInterface {
     fn disconnect(&mut self) -> Result<(), ProtocolError>;
     fn get_conn_status(&mut self) -> Result<u8, ProtocolError>;
     fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), ProtocolError>;
+    fn req_host_by_name(&mut self, hostname: &str) -> Result<u8, ProtocolError>;
+    fn get_host_by_name(&mut self) -> Result<[u8; 8], ProtocolError>;
     fn resolve(&mut self, hostname: &str) -> Result<IpAddress, ProtocolError>;
 }
 

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -18,6 +18,7 @@ pub(crate) enum NinaCommand {
     GetConnStatus = 0x20u8,
     Disconnect = 0x30u8,
     SetDNSConfig = 0x15u8,
+    GetHostByName = 0x35u8
 }
 
 pub(crate) trait NinaParam {
@@ -230,7 +231,8 @@ pub(crate) trait ProtocolInterface {
     fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), ProtocolError>;
     fn disconnect(&mut self) -> Result<(), ProtocolError>;
     fn get_conn_status(&mut self) -> Result<u8, ProtocolError>;
-    fn set_dns(&mut self, ip1: IpAddress, ip2: Option<IpAddress>) -> Result<(), ProtocolError>;
+    fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), ProtocolError>;
+    fn resolve(&mut self, hostname: &str) -> Result<IpAddress, ProtocolError>;
 }
 
 #[derive(Debug)]

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -248,6 +248,7 @@ where
 
             // This is to make sure we align correctly
             // 4 (start byte, command byte, number of params, end byte) + 1 byte for each param + the sum of all param lengths
+            // See https://github.com/arduino/nina-fw/blob/master/main/CommandHandler.cpp#L2153 for the actual equation.
             let command_size: u16 = 4u16 + number_of_params as u16 + param_size;
             self.pad_to_multiple_of_4(command_size);
         }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -86,7 +86,7 @@ where
         self.common.get_connection_status()
     }
 
-    /// Sets 1 or 2 DNS servers that will be contacted for hostname resolution.
+    /// Sets 1 or 2 DNS servers that are used for network hostname resolution.
     pub fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), Error> {
         self.common.set_dns(dns1, dns2)
     }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -247,8 +247,8 @@ where
             self.send_end_cmd().ok();
 
             // This is to make sure we align correctly
-            // 4 (start byte, command byte, reply byte, end byte) + the sum of all param lengths
-            let command_size: u16 = 4u16 + param_size;
+            // 4 (start byte, command byte, number of params, end byte) + 1 byte for each param + the sum of all param lengths
+            let command_size: u16 = 4u16 + number_of_params as u16 + param_size;
             self.pad_to_multiple_of_4(command_size);
         }
         self.control_pins.esp_deselect();

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -210,9 +210,9 @@ where
         ip_address.clone_from_slice(ip_slice);
 
         if ip_address != dummy {
-            return Ok(ip_address);
+            Ok(ip_address)
         } else {
-            return Err(NetworkError::DnsResolveFailed.into());
+            Err(NetworkError::DnsResolveFailed.into())
         }
     }
 }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -154,7 +154,11 @@ where
         Ok(())
     }
 
-    fn set_dns(&mut self, ip1: IpAddress, _ip2: Option<IpAddress>) -> Result<(), ProtocolError> {
+    fn set_dns_config(
+        &mut self,
+        ip1: IpAddress,
+        _ip2: Option<IpAddress>,
+    ) -> Result<(), ProtocolError> {
         // FIXME: refactor Operation so it can take different NinaParam types
         let operation = Operation::new(NinaCommand::SetDNSConfig, 1)
             // FIXME: first param should be able to be a NinaByteParam:

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -86,10 +86,12 @@ where
         self.common.get_connection_status()
     }
 
+    /// Sets 1 or 2 DNS servers that will be contacted for hostname resolution.
     pub fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), Error> {
         self.common.set_dns(dns1, dns2)
     }
 
+    /// Attempts the given hostname to an IP address using server(s) set by [set_dns].
     pub fn resolve(&mut self, hostname: &str) -> Result<IpAddress, Error> {
         self.common.resolve(hostname)
     }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -376,7 +376,7 @@ where
     }
 
     fn pad_to_multiple_of_4(&mut self, mut command_size: u16) {
-        while command_size % 4 == 0 {
+        while command_size % 4 != 0 {
             self.get_byte().ok();
             command_size += 1;
         }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -91,7 +91,7 @@ where
         self.common.set_dns(dns1, dns2)
     }
 
-    /// Attempts the given hostname to an IP address using server(s) set by [set_dns].
+    /// Queries the DNS server(s) provided via [set_dns] for the associated IP address to the provided hostname.
     pub fn resolve(&mut self, hostname: &str) -> Result<IpAddress, Error> {
         self.common.resolve(hostname)
     }


### PR DESCRIPTION
## Description
This PR attempts to satisfy the requirements of https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues/36 by adding 2 new public `Wifi` interface methods:

- `set_dns` 
  - Takes 1 or, optionally, 2 DNS server IP addresses with which to resolve hostnames.
- `resolve` 
  -  Takes a hostname and resolves to an IP address via DNS lookup.

A new example is also added which performs successful DNS lookup given valid WiFi network credentials, DNS server address, and hostname.

This PR also:
- Adds a new `network` module and `NetworkError` enum for describing errors involving Wifi networks.


#### GitHub Issue: https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues/36

### Changes
* Adds `set_dns` method
* Adds `resolve` method
* Adds `network` module and `NetworkError` enum

### Testing Strategy

Run new example by:
-  Adding valid WiFi credentials to `cross/dns/src/secrets/secrets.rs`
- `cd cross && cargo run --bin dns`

### Concerns
The WiFi NINA firmware exposes two separate commands for performing DNS lookups.
- `req_host_by_name`
- `get_host_by_name`

It is required that the two commands be used together in order to perform a successful lookup. I have chosen to combine the two into this crate's public `resolve` method rather than expose the two themselves. In the future we may decide to expose `get_host_by_name` and `req_host_by_name` publicly.