### PR TITLE
Create and use a ConnectionStatus enum

### DIFF
--- a/cross/dns/src/main.rs
+++ b/cross/dns/src/main.rs
@@ -29,6 +29,7 @@ use hal::clocks::Clock;
 use hal::pac;
 
 use esp32_wroom_rp::network::IpAddress;
+use esp32_wroom_rp::wifi::ConnectionStatus;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -116,12 +117,12 @@ fn main() -> ! {
 
     loop {
         match wifi.get_connection_status() {
-            Ok(byte) => {
-                defmt::info!("Get Connection Result: {:?}", byte);
+            Ok(status) => {
+                defmt::info!("Get Connection Result: {:?}", status);
                 let sleep: u32 = 1500;
                 delay.delay_ms(sleep);
 
-                if byte == 3 {
+                if status == ConnectionStatus::Connected {
                     defmt::info!("Connected to Network: {:?}", SSID);
 
                     // The IPAddresses of two DNS servers to resolve hostnames with.
@@ -146,7 +147,7 @@ fn main() -> ! {
                     }
 
                     wifi.leave().ok().unwrap();
-                } else if byte == 6 {
+                } else if status == ConnectionStatus::Disconnected {
                     defmt::info!("Disconnected from Network: {:?}", SSID);
                 }
             }

--- a/cross/join/src/main.rs
+++ b/cross/join/src/main.rs
@@ -10,6 +10,7 @@
 #![no_main]
 
 extern crate esp32_wroom_rp;
+use esp32_wroom_rp::wifi::ConnectionStatus;
 
 include!("../../secrets/secrets.rs");
 
@@ -115,20 +116,22 @@ fn main() -> ! {
 
     loop {
         match wifi.get_connection_status() {
-            Ok(byte) => {
-                defmt::info!("Get Connection Result: {:?}", byte);
+            Ok(status) => {
+                defmt::info!("Get Connection Result: {:?}", status);
                 let sleep: u32 = 1500;
                 delay.delay_ms(sleep);
 
-                if byte == 3 {
+                if status == ConnectionStatus::Connected {
                     defmt::info!("Connected to Network: {:?}", SSID);
 
                     defmt::info!("Sleeping for 5 seconds before disconnecting...");
                     delay.delay_ms(5000);
 
                     wifi.leave().ok().unwrap();
-                } else if byte == 6 {
+                } else if status == ConnectionStatus::Disconnected {
                     defmt::info!("Disconnected from Network: {:?}", SSID);
+                } else {
+                    defmt::info!("Unhandled WiFi connection status: {:?}", status);
                 }
             }
             Err(e) => {

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -101,6 +101,8 @@ use protocol::{ProtocolError, ProtocolInterface};
 use defmt::{write, Format, Formatter};
 use embedded_hal::blocking::delay::DelayMs;
 
+use self::wifi::ConnectionStatus;
+
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 
 /// Highest level error types for this crate.
@@ -210,7 +212,7 @@ where
         self.protocol_handler.disconnect()
     }
 
-    fn get_connection_status(&mut self) -> Result<u8, Error> {
+    fn get_connection_status(&mut self) -> Result<ConnectionStatus, Error> {
         self.protocol_handler.get_conn_status()
     }
 

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -8,6 +8,8 @@ use defmt::{write, Format, Formatter};
 
 use heapless::{String, Vec};
 
+use super::wifi::ConnectionStatus;
+
 pub(crate) const MAX_NINA_PARAM_LENGTH: usize = 255;
 
 #[repr(u8)]
@@ -231,7 +233,7 @@ pub(crate) trait ProtocolInterface {
     fn get_fw_version(&mut self) -> Result<FirmwareVersion, Error>;
     fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error>;
     fn disconnect(&mut self) -> Result<(), Error>;
-    fn get_conn_status(&mut self) -> Result<u8, Error>;
+    fn get_conn_status(&mut self) -> Result<ConnectionStatus, Error>;
     fn set_dns_config(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), Error>;
     fn req_host_by_name(&mut self, hostname: &str) -> Result<u8, Error>;
     fn get_host_by_name(&mut self) -> Result<[u8; 8], Error>;

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -18,6 +18,8 @@ use embedded_hal::blocking::spi::Transfer;
 
 use core::convert::Infallible;
 
+use super::wifi::ConnectionStatus;
+
 // FIXME: remove before commit
 //use defmt_rtt as _;
 
@@ -82,7 +84,7 @@ where
     ///
     /// NOTE: A future version will provide a enumerated type instead of the raw integer values
     /// from the NINA firmware.
-    pub fn get_connection_status(&mut self) -> Result<u8, Error> {
+    pub fn get_connection_status(&mut self) -> Result<ConnectionStatus, Error> {
         self.common.get_connection_status()
     }
 
@@ -135,7 +137,7 @@ where
         Ok(())
     }
 
-    fn get_conn_status(&mut self) -> Result<u8, Error> {
+    fn get_conn_status(&mut self) -> Result<ConnectionStatus, Error> {
         let operation =
             Operation::new(NinaCommand::GetConnStatus, 1).with_no_params(NinaNoParams::new(""));
 
@@ -143,7 +145,8 @@ where
 
         let result = self.receive(&operation)?;
 
-        Ok(result[0])
+        // TODO:
+        Ok(ConnectionStatus::Connected)
     }
 
     fn disconnect(&mut self) -> Result<(), Error> {

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -145,8 +145,7 @@ where
 
         let result = self.receive(&operation)?;
 
-        // TODO:
-        Ok(ConnectionStatus::Connected)
+        Ok(ConnectionStatus::from(result[0]))
     }
 
     fn disconnect(&mut self) -> Result<(), Error> {

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -1,5 +1,7 @@
 pub use crate::spi::Wifi;
 
+use defmt::{write, Format, Formatter};
+
 /// An enumerated type that represents the current WiFi network connection status.
 #[repr(u8)]
 #[derive(Eq, PartialEq, PartialOrd, Debug)]
@@ -45,6 +47,60 @@ impl From<u8> for ConnectionStatus {
             9   => ConnectionStatus::ApFailed,
             255 => ConnectionStatus::NoEsp32,
             _   => ConnectionStatus::Invalid,
+        }
+    }
+}
+
+impl Format for ConnectionStatus {
+    fn format(&self, fmt: Formatter) {
+        match self {
+            ConnectionStatus::NoEsp32 => write!(
+                fmt,"No device is connected to hardware"
+                ),
+            ConnectionStatus::Idle => write!(
+                fmt,
+                "Temporary status while attempting to connect to WiFi network"
+                ),
+            ConnectionStatus::NoActiveSsid => write!(
+                fmt,
+                "No SSID is available"
+                ),
+            ConnectionStatus::ScanCompleted => write!(
+                fmt,
+                "WiFi network scan has finished"
+                ),
+            ConnectionStatus::Connected => write!(
+                fmt,
+                "Device is connected to WiFi network"
+                ),
+            ConnectionStatus::Failed => write!(
+                fmt,
+                "Device failed to connect to WiFi network"
+                ),
+            ConnectionStatus::Lost => write!(
+                fmt,
+                "Device lost connection to WiFi network"
+                ),
+            ConnectionStatus::Disconnected => write!(
+                fmt,
+                "Device disconnected from WiFi network"
+                ),
+            ConnectionStatus::ApListening => write!(
+                fmt,
+                "Device is lstening for connections in Access Point mode"
+                ),
+            ConnectionStatus::ApConnected => write!(
+                fmt,
+                "Device is connected in Access Point mode"
+                ),
+            ConnectionStatus::ApFailed => write!(
+                fmt,
+                "Device failed to make connection in Access Point mode"
+                ),
+            ConnectionStatus::Invalid => write!(
+                fmt,
+                "Unexpected value returned from device, reset may be required"
+                ),
         }
     }
 }

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -7,7 +7,7 @@ pub enum ConnectionStatus {
     /// No device is connected to hardware
     NoEsp32 = 255,
     /// Temporary status while attempting to connect to WiFi network
-    Idle = 0, // Assigned by WiFi.begin() in the Reference Library, is this relevant?
+    Idle = 0,
     /// No SSID is available
     NoActiveSsid,
     /// WiFi network scan has finished
@@ -25,7 +25,7 @@ pub enum ConnectionStatus {
     /// Device is connected in Access Point mode
     ApConnected,
     /// Device failed to make connection in Access Point mode
-    ApFailed, // Not in the Reference Library
+    ApFailed,
     /// Unexpected value returned from device, reset may be required
     Invalid,
 }

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -16,3 +16,22 @@ pub enum ConnectionStatus {
     ApConnected,
     ApFailed, // Not in the Reference Library
 }
+
+impl From<u8> for ConnectionStatus {
+    fn from(status: u8) -> ConnectionStatus {
+        match status {
+            0 => ConnectionStatus::Idle,
+            1 => ConnectionStatus::NoActiveSsid,
+            2 => ConnectionStatus::ScanCompleted,
+            3 => ConnectionStatus::Connected,
+            4 => ConnectionStatus::Failed,
+            5 => ConnectionStatus::Lost,
+            6 => ConnectionStatus::Disconnected,
+            7 => ConnectionStatus::ApListening,
+            8 => ConnectionStatus::ApConnected,
+            9 => ConnectionStatus::ApFailed,
+            255 => ConnectionStatus::NoEsp32,
+            _ => panic!("Unexpected value: {}", status),
+        }
+    }
+}

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -1,1 +1,18 @@
 pub use crate::spi::Wifi;
+
+/// Defines the WiFi network connection status
+#[repr(u8)]
+#[derive(Eq, PartialEq, PartialOrd, Debug)]
+pub enum ConnectionStatus {
+    NoEsp32 = 255,
+    Idle = 0, // Assigned by WiFi.begin() in the Reference Library, is this relevant?
+    NoActiveSsid,
+    ScanCompleted,
+    Connected,
+    Failed,
+    Lost,
+    Disconnected,
+    ApListening,
+    ApConnected,
+    ApFailed, // Not in the Reference Library
+}

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -15,23 +15,24 @@ pub enum ConnectionStatus {
     ApListening,
     ApConnected,
     ApFailed, // Not in the Reference Library
+    Invalid,
 }
 
 impl From<u8> for ConnectionStatus {
     fn from(status: u8) -> ConnectionStatus {
         match status {
-            0 => ConnectionStatus::Idle,
-            1 => ConnectionStatus::NoActiveSsid,
-            2 => ConnectionStatus::ScanCompleted,
-            3 => ConnectionStatus::Connected,
-            4 => ConnectionStatus::Failed,
-            5 => ConnectionStatus::Lost,
-            6 => ConnectionStatus::Disconnected,
-            7 => ConnectionStatus::ApListening,
-            8 => ConnectionStatus::ApConnected,
-            9 => ConnectionStatus::ApFailed,
+            0   => ConnectionStatus::Idle,
+            1   => ConnectionStatus::NoActiveSsid,
+            2   => ConnectionStatus::ScanCompleted,
+            3   => ConnectionStatus::Connected,
+            4   => ConnectionStatus::Failed,
+            5   => ConnectionStatus::Lost,
+            6   => ConnectionStatus::Disconnected,
+            7   => ConnectionStatus::ApListening,
+            8   => ConnectionStatus::ApConnected,
+            9   => ConnectionStatus::ApFailed,
             255 => ConnectionStatus::NoEsp32,
-            _ => panic!("Unexpected value: {}", status),
+            _   => ConnectionStatus::Invalid,
         }
     }
 }

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -1,20 +1,32 @@
 pub use crate::spi::Wifi;
 
-/// Defines the WiFi network connection status
+/// An enumerated type that represents the current WiFi network connection status.
 #[repr(u8)]
 #[derive(Eq, PartialEq, PartialOrd, Debug)]
 pub enum ConnectionStatus {
+    /// No device is connected to hardware
     NoEsp32 = 255,
+    /// Temporary status while attempting to connect to WiFi network
     Idle = 0, // Assigned by WiFi.begin() in the Reference Library, is this relevant?
+    /// No SSID is available
     NoActiveSsid,
+    /// WiFi network scan has finished
     ScanCompleted,
+    /// Device is connected to WiFi network
     Connected,
+    /// Device failed to connect to WiFi network
     Failed,
+    /// Device lost connection to WiFi network
     Lost,
+    /// Device disconnected from WiFi network
     Disconnected,
+    /// Device is listening for connections in Access Point mode
     ApListening,
+    /// Device is connected in Access Point mode
     ApConnected,
+    /// Device failed to make connection in Access Point mode
     ApFailed, // Not in the Reference Library
+    /// Unexpected value returned from device, reset may be required
     Invalid,
 }
 


### PR DESCRIPTION
## Description
This PR attempts to satisfy the requirements of #42 by introducing a new `ConnectionStatus` enum type.

The variants of `ConnectionStatus` are intended to align with the [official Nina documentation](https://www.arduino.cc/reference/en/libraries/wifinina/wifi.status/), but slightly renamed to be more informative.

The enum is currently defined in `src/wifi.rs` as a forward-looking design move.
 
#### GitHub Issue: Closes #42 

### Changes
* Replace direct byte comparison with `ConnectionStatus` enum

### Testing Strategy

Testing `cross/` in the usual way should work as intended. There should be no functional difference in this PR. (I have not run tests).

### Concerns

I worked with Jim on this as an intro problem, the changes in `src/{lib.rs,spi.rs}` are my own guesses :)

At least two variants should be explored further, and they have comments explaining why.