### PR TITLE
Clean up imports

### DIFF
--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -84,24 +84,22 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 
-/// Fundamental interface for creating and send/receiving data to/from a TCP server.
-pub mod tcp_client;
-
 pub mod gpio;
-/// Fundamental interface for controlling a connected ESP32-WROOM NINA firmware-based Wifi board.
-pub mod wifi;
-
 /// Responsible for interactions over a WiFi network and also contains related types.
 pub mod network;
 /// Responsible for interactions with NINA firmware over a data bus.
 pub mod protocol;
+/// Fundamental interface for creating and send/receiving data to/from a TCP server.
+pub mod tcp_client;
+/// Fundamental interface for controlling a connected ESP32-WROOM NINA firmware-based Wifi board.
+pub mod wifi;
 
 mod spi;
 
+use defmt::{write, Format, Formatter};
+
 use network::NetworkError;
 use protocol::ProtocolError;
-
-use defmt::{write, Format, Formatter};
 
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -99,6 +99,7 @@ mod spi;
 use defmt::{write, Format, Formatter};
 
 use network::NetworkError;
+
 use protocol::ProtocolError;
 
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -7,7 +7,9 @@ use defmt::{write, Format, Formatter};
 use heapless::{String, Vec};
 
 use super::network::{ConnectionState, IpAddress, Port, Socket, TransportMode};
+
 use super::wifi::ConnectionStatus;
+
 use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
 
 use core::cell::RefCell;

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -1,18 +1,16 @@
 pub(crate) mod operation;
 
-use embedded_hal::blocking::delay::DelayMs;
+use core::cell::RefCell;
 
 use defmt::{write, Format, Formatter};
+
+use embedded_hal::blocking::delay::DelayMs;
 
 use heapless::{String, Vec};
 
 use super::network::{ConnectionState, IpAddress, Port, Socket, TransportMode};
-
 use super::wifi::ConnectionStatus;
-
 use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
-
-use core::cell::RefCell;
 
 pub(crate) const MAX_NINA_PARAM_LENGTH: usize = 4096;
 

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -1,6 +1,7 @@
+use heapless::Vec;
+
 use crate::protocol::{NinaAbstractParam, NinaCommand};
 
-use heapless::Vec;
 const MAX_NUMBER_OF_PARAMS: usize = 6;
 
 // Encapsulates all information needed to execute commands against Nina Firmware.

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -1,6 +1,6 @@
 use heapless::Vec;
 
-use crate::protocol::{NinaAbstractParam, NinaCommand};
+use super::{NinaAbstractParam, NinaCommand};
 
 const MAX_NUMBER_OF_PARAMS: usize = 6;
 

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -1,22 +1,18 @@
 //! Serial Peripheral Interface (SPI) for Wifi
-
-use crate::network::ConnectionState;
-
-use super::gpio::EspControlInterface;
-use super::protocol::{
-    NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
-    NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolInterface,
-};
-
-use super::network::{IpAddress, NetworkError, Port, Socket, TransportMode};
-use super::protocol::{operation::Operation, ProtocolError};
-use super::wifi::ConnectionStatus;
-use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
+use core::convert::Infallible;
 
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
-use core::convert::Infallible;
+use super::gpio::EspControlInterface;
+use super::network::{ConnectionState, IpAddress, NetworkError, Port, Socket, TransportMode};
+use super::protocol::operation::Operation;
+use super::protocol::{
+    NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
+    NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolError, ProtocolInterface,
+};
+use super::wifi::ConnectionStatus;
+use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
 
 // TODO: this should eventually move into NinaCommandHandler
 #[repr(u8)]

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -5,13 +5,18 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
 use super::gpio::EspControlInterface;
+
 use super::network::{ConnectionState, IpAddress, NetworkError, Port, Socket, TransportMode};
+
 use super::protocol::operation::Operation;
+
 use super::protocol::{
     NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
     NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolError, ProtocolInterface,
 };
+
 use super::wifi::ConnectionStatus;
+
 use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
 
 // TODO: this should eventually move into NinaCommandHandler

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -5,18 +5,13 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
 use super::gpio::EspControlInterface;
-
 use super::network::{ConnectionState, IpAddress, NetworkError, Port, Socket, TransportMode};
-
 use super::protocol::operation::Operation;
-
 use super::protocol::{
     NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
     NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolError, ProtocolInterface,
 };
-
 use super::wifi::ConnectionStatus;
-
 use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
 
 // TODO: this should eventually move into NinaCommandHandler

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -4,15 +4,11 @@ use embedded_hal::blocking::spi::Transfer;
 use heapless::String;
 
 use super::gpio::EspControlInterface;
-
 use super::network::{
     ConnectionState, Hostname, IpAddress, NetworkError, Port, Socket, TransportMode,
 };
-
 use super::protocol::{NinaProtocolHandler, ProtocolInterface};
-
 use super::wifi::Wifi;
-
 use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
 
 const MAX_HOSTNAME_LENGTH: usize = 255;

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -1,16 +1,15 @@
-use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
-use crate::{network::NetworkError, wifi::Wifi};
-
-use super::protocol::NinaProtocolHandler;
-use crate::gpio::EspControlInterface;
-use crate::protocol::ProtocolInterface;
-
-use super::network::{ConnectionState, Hostname, IpAddress, Port, Socket, TransportMode};
-
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
 use heapless::String;
+
+use super::gpio::EspControlInterface;
+use super::network::{
+    ConnectionState, Hostname, IpAddress, NetworkError, Port, Socket, TransportMode,
+};
+use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+use super::wifi::Wifi;
+use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
 
 const MAX_HOSTNAME_LENGTH: usize = 255;
 

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -4,11 +4,15 @@ use embedded_hal::blocking::spi::Transfer;
 use heapless::String;
 
 use super::gpio::EspControlInterface;
+
 use super::network::{
     ConnectionState, Hostname, IpAddress, NetworkError, Port, Socket, TransportMode,
 };
+
 use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+
 use super::wifi::Wifi;
+
 use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
 
 const MAX_HOSTNAME_LENGTH: usize = 255;

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -1,16 +1,14 @@
-use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::spi::Transfer;
+use core::cell::RefCell;
 
 use defmt::{write, Format, Formatter};
 
-use super::{Error, FirmwareVersion};
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::blocking::spi::Transfer;
 
 use super::gpio::EspControlInterface;
-use super::protocol::{NinaProtocolHandler, ProtocolInterface};
-
-use core::cell::RefCell;
-
 use super::network::IpAddress;
+use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+use super::{Error, FirmwareVersion};
 
 /// An enumerated type that represents the current WiFi network connection status.
 #[repr(u8)]

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -2,15 +2,11 @@ use core::cell::RefCell;
 
 use defmt::{write, Format, Formatter};
 
-use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::spi::Transfer;
+use embedded_hal::blocking::{delay::DelayMs, spi::Transfer};
 
 use super::gpio::EspControlInterface;
-
 use super::network::IpAddress;
-
 use super::protocol::{NinaProtocolHandler, ProtocolInterface};
-
 use super::{Error, FirmwareVersion};
 
 /// An enumerated type that represents the current WiFi network connection status.

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -6,8 +6,11 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
 use super::gpio::EspControlInterface;
+
 use super::network::IpAddress;
+
 use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+
 use super::{Error, FirmwareVersion};
 
 /// An enumerated type that represents the current WiFi network connection status.


### PR DESCRIPTION
## Description

This PR simplifies and cleans up our imports.

I used the following guidelines when making changes:
- Imports external to our crate come before internal imports
- Prefer `super` over `crate` in situations where both are valid as `super` is a relative identifier which means we can move around module nesting with less risk of needing to update the `use` statements. Ex. moving `spi` to `protocol::spi` our import declarations would stay the same with `super` vs needing to add `protocol` if we were using `crate`
- Group imports with the same base without newlines. Ex. imports that begin with `embedded_hal` are grouped. `super` doesn't count as a base here.
- All groups are separated with a newline
- All imports are in alphabetical order within their source (external vs internal) and within their groupings.

These guidelines are arbitrary and up for discussion. When we come to consensus on what makes sense we may want to codify these guidelines in some type of style guide. I could not find one on the web that proposed guidelines for imports. 

Some other ideas:
- Grouping by language structures. Ex. all enums, all structs.


#### GitHub Issue: closes #55 

### Changes
* Update imports based on the above guidelines
