### PR TITLE
Mature documentation and ready for publishing to crates.io

### DIFF
--- a/cross/get_fw_version/src/main.rs
+++ b/cross/get_fw_version/src/main.rs
@@ -8,8 +8,6 @@
 #![no_std]
 #![no_main]
 
-extern crate esp32_wroom_rp;
-
 // The macro for our start-up function
 use cortex_m_rt::entry;
 
@@ -25,6 +23,9 @@ use embedded_hal::spi::MODE_0;
 use fugit::RateExtU32;
 use hal::clocks::Clock;
 use hal::pac;
+
+use esp32_wroom_rp::gpio::EspControlPins;
+use esp32_wroom_rp::wifi::Wifi;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -92,7 +93,7 @@ fn main() -> ! {
         &MODE_0,
     );
 
-    let esp_pins = esp32_wroom_rp::gpio::EspControlPins {
+    let esp_pins = EspControlPins {
         // CS on pin x (GPIO7)
         cs: pins.gpio7.into_mode::<hal::gpio::PushPullOutput>(),
         // GPIO0 on pin x (GPIO2)
@@ -102,7 +103,7 @@ fn main() -> ! {
         // ACK on pin x (GPIO10)
         ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
     };
-    let mut wifi = esp32_wroom_rp::wifi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
+    let mut wifi = Wifi::init(spi, esp_pins, &mut delay).unwrap();
     let firmware_version = wifi.firmware_version();
     defmt::info!("NINA firmware version: {:?}", firmware_version);
 

--- a/esp32-wroom-rp/src/gpio.rs
+++ b/esp32-wroom-rp/src/gpio.rs
@@ -1,4 +1,4 @@
-//! GPIO pin control interface of a connected ESP32-WROOM target Wifi board.
+//! GPIO pin control interface of a connected ESP32-WROOM target WiFi board.
 //!
 //! ## Usage
 //!

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -1,18 +1,19 @@
 //! esp32-wroom-rp
 //!
-//! This crate is an Espressif ESP32-WROOM WiFi driver implementation for RP2040 series microcontroller implemented in Rust.
-//! Supports the [ESP32-WROOM-32E](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf), [ESP32-WROOM-32UE](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf) modules.
-//! Future implementations will support the [ESP32-WROOM-DA](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-da_datasheet_en.pdf) module.
+//! This crate is an Espressif ESP32-WROOM WiFi module communications driver for RP2040 series microcontroller implemented in Rust.
+//! It currently supports the [ESP32-WROOM-32E](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf)
+//! and [ESP32-WROOM-32UE](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf) modules.
+//! Future implementations intend to add support for the [ESP32-WROOM-DA](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-da_datasheet_en.pdf) module.
 //!
 //! It's intended to communicate with recent versions of most [Arduino-derived WiFiNINA firmwares](https://www.arduino.cc/reference/en/libraries/wifinina/)
-//! that run on an ESP32-WROOM-XX WiFi module. For example, Adafruit makes such WiFi hardware referred to as the [Airlift](https://www.adafruit.com/product/4201) and maintains its [firmware](https://github.com/adafruit/nina-fw).
+//! that run on an ESP32-WROOM-XX WiFi module. For example, Adafruit makes such WiFi hardware, referred to as the [Airlift](https://www.adafruit.com/product/4201), and maintains its [firmware](https://github.com/adafruit/nina-fw).
 //! 
 //! This driver is implemented on top of [embedded-hal](https://github.com/rust-embedded/embedded-hal/), which makes it platform-independent, but is currently only intended
 //! to be used with [rp2040-hal](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal) for your application.
 //! 
-//! Please see the README.md for details on where to obtain and how to connect your RP2040-based device (e.g. Pico) to your ESP32-WROOM-XX WiFI board.
+//! Please see the README.md for details on where to obtain and how to connect your RP2040-based device (e.g. Pico) to your ESP32-WROOM-XX WiFi board.
 //! 
-//! Once connected, note that all communication with the WiFI board occurs via a SPI bus. As the example below (and all examples under the directory `cross/`)
+//! Once connected, note that all communication with the WiFi board occurs via a SPI bus. As the example below (and all examples under the directory `cross/`)
 //! show, you first need to create an `embedded_hal::spi::Spi` instance. See the [rp2040-hal documentation](https://docs.rs/rp2040-hal/0.6.0/rp2040_hal/spi/index.html) along
 //! with the datasheet for your device on what specific SPI ports are available to you.
 //! 
@@ -137,6 +138,11 @@
 //!     loop {}
 //! }
 //! ```
+//! 
+//! ## More examples
+//! 
+//! Please refer to the `cross/` directory in this crate's source for examples that demonstrate how to use every part of its public API.
+//! 
 
 #![doc(html_root_url = "https://docs.rs/esp32-wroom-rp")]
 #![doc(issue_tracker_base_url = "https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues")]

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -149,18 +149,18 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 
-pub mod tcp_client;
 pub mod gpio;
-pub mod wifi;
 pub mod network;
 pub mod protocol;
+pub mod tcp_client;
+pub mod wifi;
 
 mod spi;
 
+use defmt::{write, Format, Formatter};
+
 use network::NetworkError;
 use protocol::ProtocolError;
-
-use defmt::{write, Format, Formatter};
 
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -4,6 +4,9 @@
 //! Supports the [ESP32-WROOM-32E](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf), [ESP32-WROOM-32UE](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf) modules.
 //! Future implementations will support the [ESP32-WROOM-DA](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-da_datasheet_en.pdf) module.
 //!
+//! It's intended to communicate with recent versions of most [Arduino-derived WiFiNINA firmwares](https://www.arduino.cc/reference/en/libraries/wifinina/)
+//! that run on an ESP32-WROOM-XX WiFi module. For example, Adafruit makes such WiFi hardware referred to as the [Airlift](https://www.adafruit.com/product/4201) and maintains its [firmware](https://github.com/adafruit/nina-fw).
+//! 
 //! This driver is implemented on top of [embedded-hal](https://github.com/rust-embedded/embedded-hal/), which makes it platform-independent, but is currently only intended
 //! to be used with [rp2040-hal](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal) for your application.
 //! 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -7,19 +7,19 @@
 //!
 //! It's intended to communicate with recent versions of most [Arduino-derived WiFiNINA firmwares](https://www.arduino.cc/reference/en/libraries/wifinina/)
 //! that run on an ESP32-WROOM-XX WiFi module. For example, Adafruit makes such WiFi hardware, referred to as the [Airlift](https://www.adafruit.com/product/4201), and maintains its [firmware](https://github.com/adafruit/nina-fw).
-//! 
+//!
 //! This driver is implemented on top of [embedded-hal](https://github.com/rust-embedded/embedded-hal/), which makes it platform-independent, but is currently only intended
 //! to be used with [rp2040-hal](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal) for your application.
-//! 
+//!
 //! Please see the README.md for details on where to obtain and how to connect your RP2040-based device (e.g. Pico) to your ESP32-WROOM-XX WiFi board.
-//! 
+//!
 //! Once connected, note that all communication with the WiFi board occurs via a SPI bus. As the example below (and all examples under the directory `cross/`)
 //! show, you first need to create an `embedded_hal::spi::Spi` instance. See the [rp2040-hal documentation](https://docs.rs/rp2040-hal/0.6.0/rp2040_hal/spi/index.html) along
 //! with the datasheet for your device on what specific SPI ports are available to you.
-//! 
+//!
 //! You'll also need to reserve 4 important [GPIO pins](https://docs.rs/rp2040-hal/0.6.0/rp2040_hal/gpio/index.html) (3 output, 1 input) that are used to mediate communication between the two boards. The examples
 //! also demonstrate how to do this through instantiating an instance of `esp32_wroom_rp::gpio::EspControlPins`.
-//! 
+//!
 //! **NOTE:** This crate is still under active development. This API will remain volatile until 1.0.0.
 //!
 //! ## Usage
@@ -50,7 +50,7 @@
 //! use fugit::RateExtU32;
 //! use hal::clocks::Clock;
 //! use hal::pac;
-//! 
+//!
 //! use esp32_wroom_rp::gpio::EspControlPins;
 //! use esp32_wroom_rp::wifi::Wifi;
 //!
@@ -59,11 +59,11 @@
 //! #[link_section = ".boot2"]
 //! #[used]
 //! pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
-//! 
+//!
 //! // External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 //! // if your board has a different frequency
 //! const XTAL_FREQ_HZ: u32 = 12_000_000u32;
-//! 
+//!
 //! // Entry point to our bare-metal application.
 //! //
 //! // The `#[entry]` macro ensures the Cortex-M start-up code calls this function
@@ -138,11 +138,11 @@
 //!     loop {}
 //! }
 //! ```
-//! 
+//!
 //! ## More examples
-//! 
+//!
 //! Please refer to the `cross/` directory in this crate's source for examples that demonstrate how to use every part of its public API.
-//! 
+//!
 
 #![doc(html_root_url = "https://docs.rs/esp32-wroom-rp")]
 #![doc(issue_tracker_base_url = "https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp/issues")]

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -73,10 +73,10 @@
 //!     // Grab our singleton objects
 //!     let mut pac = pac::Peripherals::take().unwrap();
 //!     let core = pac::CorePeripherals::take().unwrap();
-
+//!
 //!     // Set up the watchdog driver - needed by the clock setup code
 //!     let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
-
+//!
 //!     // Configure the clocks
 //!     let clocks = hal::clocks::init_clocks_and_plls(
 //!         XTAL_FREQ_HZ,

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -120,7 +120,7 @@
 //!         &MODE_0,
 //!     );
 //!
-//!     let esp_pins = esp32_wroom_rp::gpio::EspControlPins {
+//!     let esp_pins = EspControlPins {
 //!         // CS on pin x (GPIO7)
 //!         cs: pins.gpio7.into_mode::<hal::gpio::PushPullOutput>(),
 //!         // GPIO0 on pin x (GPIO2)
@@ -130,11 +130,11 @@
 //!         // ACK on pin x (GPIO10)
 //!         ack: pins.gpio10.into_mode::<hal::gpio::FloatingInput>(),
 //!     };
-//!     let mut wifi = esp32_wroom_rp::wifi::Wifi::init(spi, esp_pins, &mut delay).unwrap();
+//!     let mut wifi = Wifi::init(spi, esp_pins, &mut delay).unwrap();
 //!     let firmware_version = wifi.firmware_version();
 //!     defmt::info!("NINA firmware version: {:?}", firmware_version);
 //!
-//!     defmt::info!("Entering main loop");
+//!     // Infinitely sit in a main loop
 //!     loop {}
 //! }
 //! ```

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -160,6 +160,7 @@ mod spi;
 use defmt::{write, Format, Formatter};
 
 use network::NetworkError;
+
 use protocol::ProtocolError;
 
 const ARRAY_LENGTH_PLACEHOLDER: usize = 8;

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -149,16 +149,10 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 
-/// Fundamental interface for creating and send/receiving data to/from a TCP server.
 pub mod tcp_client;
-
 pub mod gpio;
-/// Fundamental interface for controlling a connected ESP32-WROOM NINA firmware-based Wifi board.
 pub mod wifi;
-
-/// Responsible for interactions over a WiFi network and also contains related types.
 pub mod network;
-/// Responsible for interactions with NINA firmware over a data bus.
 pub mod protocol;
 
 mod spi;

--- a/esp32-wroom-rp/src/network.rs
+++ b/esp32-wroom-rp/src/network.rs
@@ -1,10 +1,5 @@
 //! Defines common network functions, types and error definitions.
 //!
-//! ## Usage
-//!
-//! ```no_run
-//! ```
-//!
 
 use defmt::{write, Format, Formatter};
 

--- a/esp32-wroom-rp/src/network.rs
+++ b/esp32-wroom-rp/src/network.rs
@@ -1,3 +1,11 @@
+//! Defines common network functions, types and error definitions.
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! ```
+//!
+
 use defmt::{write, Format, Formatter};
 
 /// A four byte array type alias representing an IP address.

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -15,7 +15,9 @@ use defmt::{write, Format, Formatter};
 use heapless::{String, Vec};
 
 use super::network::{ConnectionState, IpAddress, Port, Socket, TransportMode};
+
 use super::wifi::ConnectionStatus;
+
 use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
 
 use core::cell::RefCell;

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -1,10 +1,5 @@
 //! Defines functions, types and error definitions related to the WiFiNINA protocol communication specification.
 //!
-//! ## Usage
-//!
-//! ```no_run
-//! ```
-//!
 
 pub(crate) mod operation;
 

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -1,3 +1,11 @@
+//! Defines functions, types and error definitions related to the WiFiNINA protocol communication specification.
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! ```
+//!
+
 pub(crate) mod operation;
 
 use embedded_hal::blocking::delay::DelayMs;

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -8,19 +8,17 @@
 
 pub(crate) mod operation;
 
-use embedded_hal::blocking::delay::DelayMs;
+use core::cell::RefCell;
 
 use defmt::{write, Format, Formatter};
+
+use embedded_hal::blocking::delay::DelayMs;
 
 use heapless::{String, Vec};
 
 use super::network::{ConnectionState, IpAddress, Port, Socket, TransportMode};
-
 use super::wifi::ConnectionStatus;
-
 use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
-
-use core::cell::RefCell;
 
 pub(crate) const MAX_NINA_PARAM_LENGTH: usize = 4096;
 

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -1,6 +1,7 @@
+use heapless::Vec;
+
 use crate::protocol::{NinaAbstractParam, NinaCommand};
 
-use heapless::Vec;
 const MAX_NUMBER_OF_PARAMS: usize = 6;
 
 // Encapsulates all information needed to execute commands against Nina Firmware.

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -1,6 +1,6 @@
 use heapless::Vec;
 
-use crate::protocol::{NinaAbstractParam, NinaCommand};
+use super::{NinaAbstractParam, NinaCommand};
 
 const MAX_NUMBER_OF_PARAMS: usize = 6;
 

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -1,22 +1,18 @@
 //! Serial Peripheral Interface (SPI) for Wifi
-
-use crate::network::ConnectionState;
-
-use super::gpio::EspControlInterface;
-use super::protocol::{
-    NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
-    NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolInterface,
-};
-
-use super::network::{IpAddress, NetworkError, Port, Socket, TransportMode};
-use super::protocol::{operation::Operation, ProtocolError};
-use super::wifi::ConnectionStatus;
-use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
+use core::convert::Infallible;
 
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
-use core::convert::Infallible;
+use super::gpio::EspControlInterface;
+use super::network::{ConnectionState, IpAddress, NetworkError, Port, Socket, TransportMode};
+use super::protocol::operation::Operation;
+use super::protocol::{
+    NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
+    NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolError, ProtocolInterface,
+};
+use super::wifi::ConnectionStatus;
+use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
 
 // TODO: this should eventually move into NinaCommandHandler
 #[repr(u8)]

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -1,4 +1,10 @@
-//! Serial Peripheral Interface (SPI) for Wifi
+//! Serial Peripheral Interface (SPI)
+//!
+//! Contains all SPI bus related structs, types and errors. Also responsible for
+//! implementing WifiNINA protocol communication over a selected SPI interface.
+//!
+//! Note: Currently everything in this file is private and considered internal to the crate.
+//!
 use core::convert::Infallible;
 
 use embedded_hal::blocking::delay::DelayMs;

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -5,13 +5,18 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
 use super::gpio::EspControlInterface;
+
 use super::network::{ConnectionState, IpAddress, NetworkError, Port, Socket, TransportMode};
+
 use super::protocol::operation::Operation;
+
 use super::protocol::{
     NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
     NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolError, ProtocolInterface,
 };
+
 use super::wifi::ConnectionStatus;
+
 use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
 
 // TODO: this should eventually move into NinaCommandHandler

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -5,18 +5,13 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
 use super::gpio::EspControlInterface;
-
 use super::network::{ConnectionState, IpAddress, NetworkError, Port, Socket, TransportMode};
-
 use super::protocol::operation::Operation;
-
 use super::protocol::{
     NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
     NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolError, ProtocolInterface,
 };
-
 use super::wifi::ConnectionStatus;
-
 use super::{Error, FirmwareVersion, ARRAY_LENGTH_PLACEHOLDER};
 
 // TODO: this should eventually move into NinaCommandHandler

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -6,19 +6,18 @@
 //! ```
 //! 
 
-use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
-use crate::{network::NetworkError, wifi::Wifi};
-
-use super::protocol::NinaProtocolHandler;
-use crate::gpio::EspControlInterface;
-use crate::protocol::ProtocolInterface;
-
-use super::network::{ConnectionState, Hostname, IpAddress, Port, Socket, TransportMode};
-
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
 use heapless::String;
+
+use super::gpio::EspControlInterface;
+use super::network::{
+    ConnectionState, Hostname, IpAddress, NetworkError, Port, Socket, TransportMode,
+};
+use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+use super::wifi::Wifi;
+use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
 
 const MAX_HOSTNAME_LENGTH: usize = 255;
 

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -170,15 +170,9 @@ where
         self.mode
     }
 
-    // TODO: Make this non-public
-    /// Requests a Socket
+    /// Request current `Socket` handle.
     pub fn get_socket(&mut self) -> Result<Socket, Error> {
         self.protocol_handler.get_socket()
-    }
-
-    /// Returns [`Socket`] reference set by calling [`TcpClient::get_socket`]
-    fn socket(&self) -> Socket {
-        self.socket.unwrap()
     }
 
     /// Send a string slice of data to a connected server.

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -1,8 +1,43 @@
-//! Send/receive data to/from a TCP server.
+//! Send/receive data to/from a TCP server and associated types.
 //!
 //! ## Usage
 //!
 //! ```no_run
+//! let hostname = "github.com";
+//! // let ip_address: IpAddress = [140, 82, 114, 3]; // github.com
+
+//! let port: Port = 80;
+//! let mode: TransportMode = TransportMode::Tcp;
+//! if let Err(e) = TcpClient::build(&mut wifi).connect(
+//!     hostname,
+//!     port,
+//!     mode,
+//!     &mut delay,
+//!     &mut |tcp_client| {
+//!         defmt::info!(
+//!             "TCP connection to {:?}:{:?} successful",
+//!             hostname,
+//!             port
+//!         );
+//!         defmt::info!("Hostname: {:?}", tcp_client.server_hostname());
+//!         defmt::info!("Sending HTTP Document: {:?}", http_document.as_str());
+//!         match tcp_client.send_data(&http_document) {
+//!             Ok(response) => {
+//!                 defmt::info!("Response: {:?}", response)
+//!             }
+//!             Err(e) => {
+//!                 defmt::error!("Response error: {:?}", e)
+//!             }
+//!         }
+//!     },
+//! ) {
+//!     defmt::error!(
+//!         "TCP connection to {:?}:{:?} failed: {:?}",
+//!         hostname,
+//!         port,
+//!         e
+//!     );
+//! }
 //! ```
 //! 
 
@@ -21,11 +56,11 @@ use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
 
 const MAX_HOSTNAME_LENGTH: usize = 255;
 
-/// Connect trait that allows for a `TcpClient` instance to connect to a remote
-/// server by providing either a `Hostname` or an `IpAddress`. This trait also
-/// makes it possible to implement and support IPv6 addresses.
+/// Allows for a [`TcpClient`] instance to connect to a remote server by providing
+/// either a [`Hostname`] or an [`IpAddress`]. This trait also makes it possible to
+/// implement and support IPv6 addresses.
 pub trait Connect<'a, S, B, C> {
-    /// Connects to `server` on `port` using transport layer `mode`.
+    /// Enable a client to connect to `server` on `port` using transport layer `mode`.
     fn connect<F: FnMut(&mut TcpClient<'a, B, C>), D: DelayMs<u16>>(
         &mut self,
         server: S,
@@ -36,7 +71,7 @@ pub trait Connect<'a, S, B, C> {
     ) -> Result<(), Error>;
 }
 
-/// A client that connects to and performs send/receive operations with a remote
+/// A client type that connects to and performs send/receive operations with a remote
 /// server using the TCP protocol.
 pub struct TcpClient<'a, B, C> {
     pub(crate) protocol_handler: &'a mut NinaProtocolHandler<B, C>,
@@ -99,7 +134,7 @@ where
     B: Transfer<u8>,
     C: EspControlInterface,
 {
-    /// Builds a new instance of a `TcpClient` provided a `Wifi` instance.
+    /// Build a new instance of a [`TcpClient`] provided a [`Wifi`] instance.
     pub fn build(wifi: &'a mut Wifi<B, C>) -> Self {
         Self {
             protocol_handler: wifi.protocol_handler.get_mut(),
@@ -111,26 +146,26 @@ where
         }
     }
 
-    /// Returns `IpAddress` of the remote server to communicate with that is
-    /// set by calling `connect()`.
+    /// Get an [`IpAddress`] of the remote server to communicate with that is
+    /// set by calling [`TcpClient::connect`].
     pub fn server_ip_address(&self) -> Option<IpAddress> {
         self.server_ip_address
     }
 
-    /// Returns `Hostname` of the remote server to communicate with that is
-    /// set by calling `connect()`.
+    /// Get a [`Hostname`] of the remote server to communicate with that is
+    /// set by calling [`TcpClient::connect`].
     pub fn server_hostname(&self) -> &str {
         self.server_hostname.as_ref().unwrap().as_str()
     }
 
-    /// Returns `Port` of the remote server to communicate with that is
-    /// set by calling `connect()`.
+    /// Get a [`Port`] of the remote server to communicate with that is
+    /// set by calling [`TcpClient::connect`].
     pub fn port(&self) -> Port {
         self.port
     }
 
-    /// Returns `TransportMode` used in communication with the remote server that is
-    /// set by calling `connect()`.
+    /// Get a [`TransportMode`] used in communication with the remote server that is
+    /// set by calling [`TcpClient::connect`].
     pub fn mode(&self) -> TransportMode {
         self.mode
     }
@@ -141,13 +176,12 @@ where
         self.protocol_handler.get_socket()
     }
 
-    // TODO: Make this non-public
-    /// Returns `Socket` reference set by calling `get_socket()`
+    /// Returns [`Socket`] reference set by calling [`TcpClient::get_socket`]
     fn socket(&self) -> Socket {
         self.socket.unwrap()
     }
 
-    /// Sends a string slice of data to a connected server.
+    /// Send a string slice of data to a connected server.
     pub fn send_data(&mut self, data: &str) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], Error> {
         self.protocol_handler
             .send_data(data, self.socket.unwrap_or_default())

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -12,15 +12,11 @@ use embedded_hal::blocking::spi::Transfer;
 use heapless::String;
 
 use super::gpio::EspControlInterface;
-
 use super::network::{
     ConnectionState, Hostname, IpAddress, NetworkError, Port, Socket, TransportMode,
 };
-
 use super::protocol::{NinaProtocolHandler, ProtocolInterface};
-
 use super::wifi::Wifi;
-
 use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
 
 const MAX_HOSTNAME_LENGTH: usize = 255;

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -12,11 +12,15 @@ use embedded_hal::blocking::spi::Transfer;
 use heapless::String;
 
 use super::gpio::EspControlInterface;
+
 use super::network::{
     ConnectionState, Hostname, IpAddress, NetworkError, Port, Socket, TransportMode,
 };
+
 use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+
 use super::wifi::Wifi;
+
 use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
 
 const MAX_HOSTNAME_LENGTH: usize = 255;

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -1,3 +1,11 @@
+//! Send/receive data to/from a TCP server.
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! ```
+//! 
+
 use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
 use crate::{network::NetworkError, wifi::Wifi};
 

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -39,7 +39,7 @@
 //!     );
 //! }
 //! ```
-//! 
+//!
 
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -196,7 +196,7 @@ where
             .set_dns_config(dns1, dns2)
     }
 
-    /// Query the DNS server(s) provided via [`set_dns`] for the associated IP address to the provided hostname.
+    /// Query the DNS server(s) provided via `set_dns` for the associated IP address to the provided hostname.
     pub fn resolve(&mut self, hostname: &str) -> Result<IpAddress, Error> {
         self.protocol_handler.borrow_mut().resolve(hostname)
     }

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -3,6 +3,52 @@
 //! ## Usage
 //!
 //! ```no_run
+//! let mut wifi = Wifi::init(spi, esp_pins, &mut delay).unwrap();
+//!
+//! let result = wifi.join(ssid, passphrase);
+//! defmt::info!("Join Result: {:?}", result);
+//!
+//! defmt::info!("Entering main loop");
+//!
+//! let mut sleep: u32 = 1500;
+//! loop {
+//!     match wifi.get_connection_status() {
+//!         Ok(status) => {
+//!             defmt::info!("Connection status: {:?}", status);
+//!             delay.delay_ms(sleep);
+//!
+//!             if status == ConnectionStatus::Connected {
+//!                 defmt::info!("Connected to network: {:?}", SSID);
+//!
+//!                 // The IPAddresses of two DNS servers to resolve hostnames with.
+//!                 // Note that failover from ip1 to ip2 is fully functional.
+//!                 let ip1: IpAddress = [9, 9, 9, 9];
+//!                 let ip2: IpAddress = [8, 8, 8, 8];
+//!                 let dns_result = wifi.set_dns(ip1, Some(ip2));
+//!
+//!                 defmt::info!("set_dns result: {:?}", dns_result);
+//!
+//!                 match wifi.resolve(hostname) {
+//!                     Ok(ip) => {
+//!                         defmt::info!("Server IP: {:?}", ip);
+//!                     }
+//!                     Err(e) => {
+//!                         defmt::error!("Failed to resolve hostname {}", hostname);
+//!                         defmt::error!("Err: {}", e);
+//!                     }
+//!                 }
+//!
+//!                 defmt::info!("Leaving network: {:?}", ssid);
+//!                 wifi.leave().ok();
+//!             } else if status == ConnectionStatus::Disconnected {
+//!                 sleep = 20000; // No need to loop as often after disconnecting
+//!             }
+//!         }
+//!         Err(e) => {
+//!             defmt::error!("Failed to get connection result: {:?}", e);
+//!         }
+//!     }
+//! }
 //! ```
 //!
 
@@ -98,7 +144,7 @@ impl Format for ConnectionStatus {
     }
 }
 
-/// Fundamental struct for controlling a connected ESP32-WROOM NINA firmware-based Wifi board.
+/// Base type for controlling an ESP32-WROOM NINA firmware-based WiFi board.
 #[derive(Debug)]
 pub struct Wifi<B, C> {
     pub(crate) protocol_handler: RefCell<NinaProtocolHandler<B, C>>,
@@ -109,8 +155,8 @@ where
     S: Transfer<u8>,
     C: EspControlInterface,
 {
-    /// Initializes the ESP32-WROOM Wifi device.
-    /// Calling this function puts the connected ESP32-WROOM device in a known good state to accept commands.
+    /// Initialize the ESP32-WROOM WiFi device.
+    /// Call this function to put the connected ESP32-WROOM device in a known good state to accept commands.
     pub fn init<D: DelayMs<u16>>(
         spi: S,
         esp32_control_pins: C,
@@ -128,42 +174,42 @@ where
         Ok(wifi)
     }
 
-    /// Retrieves the NINA firmware version contained on the connected ESP32-WROOM device (e.g. 1.7.4).
+    /// Retrieve the NINA firmware version contained on the connected ESP32-WROOM device (e.g. 1.7.4).
     pub fn firmware_version(&mut self) -> Result<FirmwareVersion, Error> {
         self.protocol_handler.borrow_mut().get_fw_version()
     }
 
-    /// Joins a WiFi network given an SSID and a Passphrase.
+    /// Join a WiFi network given an SSID and a Passphrase.
     pub fn join(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error> {
         self.protocol_handler
             .borrow_mut()
             .set_passphrase(ssid, passphrase)
     }
 
-    /// Disconnects from a joined WiFi network.
+    /// Disconnect from a previously joined WiFi network.
     pub fn leave(&mut self) -> Result<(), Error> {
         self.protocol_handler.borrow_mut().disconnect()
     }
 
-    /// Retrieves the current WiFi network connection status.
+    /// Retrieve the current WiFi network [`ConnectionStatus`].
     pub fn get_connection_status(&mut self) -> Result<ConnectionStatus, Error> {
         self.protocol_handler.borrow_mut().get_conn_status()
     }
 
-    /// Sets 1 or 2 DNS servers that are used for network hostname resolution.
+    /// Set 1 or 2 DNS servers that are used for network hostname resolution.
     pub fn set_dns(&mut self, dns1: IpAddress, dns2: Option<IpAddress>) -> Result<(), Error> {
         self.protocol_handler
             .borrow_mut()
             .set_dns_config(dns1, dns2)
     }
 
-    /// Queries the DNS server(s) provided via [set_dns] for the associated IP address to the provided hostname.
+    /// Query the DNS server(s) provided via [`set_dns`] for the associated IP address to the provided hostname.
     pub fn resolve(&mut self, hostname: &str) -> Result<IpAddress, Error> {
         self.protocol_handler.borrow_mut().resolve(hostname)
     }
 
-    /// Provides a reference to the `Spi` bus instance typically used when cleaning up
-    /// an instance of `Wifi`.
+    /// Return a reference to the `Spi` bus instance typically used when cleaning up
+    /// an instance of [`Wifi`].
     pub fn destroy(self) -> S {
         self.protocol_handler.into_inner().bus.into_inner()
     }

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -69,10 +69,8 @@ use super::{Error, FirmwareVersion};
 pub enum ConnectionStatus {
     /// No device is connected to hardware
     NoEsp32 = 255,
-    /// Temporary status while attempting to connect to WiFi network
-    Idle = 0,
     /// No SSID is available
-    NoActiveSsid,
+    NoActiveSsid = 1,
     /// WiFi network scan has finished
     ScanCompleted,
     /// Device is connected to WiFi network
@@ -96,7 +94,6 @@ pub enum ConnectionStatus {
 impl From<u8> for ConnectionStatus {
     fn from(status: u8) -> ConnectionStatus {
         match status {
-            0 => ConnectionStatus::Idle,
             1 => ConnectionStatus::NoActiveSsid,
             2 => ConnectionStatus::ScanCompleted,
             3 => ConnectionStatus::Connected,
@@ -116,10 +113,6 @@ impl Format for ConnectionStatus {
     fn format(&self, fmt: Formatter) {
         match self {
             ConnectionStatus::NoEsp32 => write!(fmt, "No device is connected to hardware"),
-            ConnectionStatus::Idle => write!(
-                fmt,
-                "Temporary status while attempting to connect to WiFi network"
-            ),
             ConnectionStatus::NoActiveSsid => write!(fmt, "No SSID is available"),
             ConnectionStatus::ScanCompleted => write!(fmt, "WiFi network scan has finished"),
             ConnectionStatus::Connected => write!(fmt, "Device is connected to WiFi network"),

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -6,19 +6,17 @@
 //! ```
 //!
 
-use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::spi::Transfer;
+use core::cell::RefCell;
 
 use defmt::{write, Format, Formatter};
 
-use super::{Error, FirmwareVersion};
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::blocking::spi::Transfer;
 
 use super::gpio::EspControlInterface;
-use super::protocol::{NinaProtocolHandler, ProtocolInterface};
-
-use core::cell::RefCell;
-
 use super::network::IpAddress;
+use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+use super::{Error, FirmwareVersion};
 
 /// An enumerated type that represents the current WiFi network connection status.
 #[repr(u8)]

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -14,8 +14,11 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 
 use super::gpio::EspControlInterface;
+
 use super::network::IpAddress;
+
 use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+
 use super::{Error, FirmwareVersion};
 
 /// An enumerated type that represents the current WiFi network connection status.

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -1,3 +1,11 @@
+//! Perform common core WiFi functions such as join a network, resolve a DNS hostname, etc.
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! ```
+//!
+
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::Transfer;
 

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -10,15 +10,11 @@ use core::cell::RefCell;
 
 use defmt::{write, Format, Formatter};
 
-use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::spi::Transfer;
+use embedded_hal::blocking::{delay::DelayMs, spi::Transfer};
 
 use super::gpio::EspControlInterface;
-
 use super::network::IpAddress;
-
 use super::protocol::{NinaProtocolHandler, ProtocolInterface};
-
 use super::{Error, FirmwareVersion};
 
 /// An enumerated type that represents the current WiFi network connection status.


### PR DESCRIPTION
## Description
This PR seeks to prepare the documentation and other miscellaneous of this crate for publishing to crates.io.


#### GitHub Issue: closes #38 

### Changes
* Matures the intro documentation to our crate to help crate users get started
* Updates the get_fw_version example in `cross/` to be the same as the one listed at the top of `lib.rs`

### Testing Strategy
Run `cargo doc` and observe that it generates crate documentation without errors or warnings.


### Concerns
None