### PR TITLE
Replace unwrap() with alternatives to avoid panics

### DIFF
--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -207,7 +207,7 @@ impl NinaConcreteParam for NinaByteParam {
 
     fn from_bytes(bytes: &[u8]) -> Self {
         let mut data_as_bytes: Vec<u8, 1> = Vec::new();
-        data_as_bytes.extend_from_slice(bytes).ok().unwrap();
+        data_as_bytes.extend_from_slice(bytes).unwrap_or_default();
         Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
@@ -240,7 +240,7 @@ impl NinaConcreteParam for NinaWordParam {
 
     fn from_bytes(bytes: &[u8]) -> Self {
         let mut data_as_bytes: Vec<u8, 2> = Vec::new();
-        data_as_bytes.extend_from_slice(bytes).ok().unwrap();
+        data_as_bytes.extend_from_slice(bytes).unwrap_or_default();
         Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
@@ -273,7 +273,7 @@ impl NinaConcreteParam for NinaSmallArrayParam {
 
     fn from_bytes(bytes: &[u8]) -> Self {
         let mut data_as_bytes: Vec<u8, MAX_NINA_PARAM_LENGTH> = Vec::new();
-        data_as_bytes.extend_from_slice(bytes).ok().unwrap();
+        data_as_bytes.extend_from_slice(bytes).unwrap_or_default();
         Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
@@ -306,7 +306,7 @@ impl NinaConcreteParam for NinaLargeArrayParam {
 
     fn from_bytes(bytes: &[u8]) -> Self {
         let mut data_as_bytes: Vec<u8, MAX_NINA_PARAM_LENGTH> = Vec::new();
-        data_as_bytes.extend_from_slice(bytes).ok().unwrap();
+        data_as_bytes.extend_from_slice(bytes).unwrap_or_default();
         Self {
             length: data_as_bytes.len() as u16,
             data: data_as_bytes,

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -26,7 +26,7 @@ impl Operation<NinaAbstractParam> {
     // on the data bus.
     pub fn param(mut self, param: NinaAbstractParam) -> Self {
         // FIXME: Vec::push() will return T when it is full, handle this gracefully
-        self.params.push(param).ok().unwrap();
+        self.params.push(param).unwrap_or(());
         self
     }
 }

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -198,7 +198,6 @@ where
             ip = self
                 .protocol_handler
                 .resolve(hostname.as_str())
-                .ok()
                 .unwrap_or_default();
         }
 

--- a/esp32-wroom-rp/src/wifi.rs
+++ b/esp32-wroom-rp/src/wifi.rs
@@ -121,7 +121,7 @@ impl Format for ConnectionStatus {
             ConnectionStatus::Disconnected => write!(fmt, "Device disconnected from WiFi network"),
             ConnectionStatus::ApListening => write!(
                 fmt,
-                "Device is lstening for connections in Access Point mode"
+                "Device is listening for connections in Access Point mode"
             ),
             ConnectionStatus::ApConnected => {
                 write!(fmt, "Device is connected in Access Point mode")


### PR DESCRIPTION
## Description
This PR modifies some `unwrap()`s which could potentially cause panics. 

There may be some which I have missed (for now!).

#### GitHub Issue: Closes #54 

### Changes

`ok().unwrap()` usually becomes `unwrap_or_default()`.

### Testing Strategy

Testing is odd here - panics weren't ever really appearing before, but they only would have shown up in corner cases. Currently, we still pass all the same tests as before using the usual testing method.

### Concerns

Just that we might be missing some.