### PR TITLE
Add git-commit hook that runs 'cargo fmt' when committing code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ cargo install flip-link
 cargo install probe-run
 ```
 
+## Set Up Git Hooks
+
+The esp32-wroom-rp repository makes use of several Git hooks to ensure that code quality standards are met and consistent. To automatically configure these hooks for your local workspace, you can run the following:
+
+./scripts/create-git-hooks
+This will create symlinks to the Git hooks, preserving any hooks that you may have already configured.
+
 ## Building the crate and running the examples
 
 To build the esp32-wroom-rp crate:

--- a/esp32-wroom-rp/README.md
+++ b/esp32-wroom-rp/README.md
@@ -135,6 +135,13 @@ cargo install flip-link
 cargo install probe-run
 ```
 
+## Set Up Git Hooks
+
+The esp32-wroom-rp repository makes use of several Git hooks to ensure that code quality standards are met and consistent. To automatically configure these hooks for your local workspace, you can run the following:
+
+./scripts/create-git-hooks
+This will create symlinks to the Git hooks, preserving any hooks that you may have already configured.
+
 ## Building the crate and running the examples
 
 To build the esp32-wroom-rp crate:

--- a/scripts/create-git-hooks
+++ b/scripts/create-git-hooks
@@ -1,0 +1,29 @@
+# This script was taken from a StackOverflow answer that can be found at
+# https://stackoverflow.com/a/3464399
+#
+# This is used under the CC BY-SA 4.0 license:
+# https://creativecommons.org/licenses/by-sa/4.0/
+#
+# This file has been modified from its original form to include a BASE_DIR variable
+# and to include creation of the Git hooks directory if it does not already exist
+
+
+#!/bin/bash
+HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-receive update post-receive post-update pre-auto-gc"
+BASE_DIR=$(git rev-parse --show-toplevel)
+HOOK_DIR=$BASE_DIR/.git/hooks
+
+if [ ! -d $HOOK_DIR ]; then
+  mkdir $HOOK_DIR
+fi
+
+for hook in $HOOK_NAMES; do
+    # If the hook already exists, is executable, and is not a symlink
+    if [ ! -h $HOOK_DIR/$hook -a -x $HOOK_DIR/$hook ]; then
+        mv $HOOK_DIR/$hook $HOOK_DIR/$hook.local
+    fi
+    # create the symlink, overwriting the file if it exists
+    # probably the only way this would happen is if you're using an old version of git
+    # -- back when the sample hooks were not executable, instead of being named ____.sample
+    ln -s -f $BASE_DIR/scripts/hooks-wrapper $HOOK_DIR/$hook
+done

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eo pipefail
+
+cargo fmt
+
+# Stage changes to files that were already staged
+git update-index --again

--- a/scripts/hooks-wrapper
+++ b/scripts/hooks-wrapper
@@ -1,0 +1,12 @@
+# This script was taken from a StackOverflow answer that can be found at
+# https://stackoverflow.com/a/3464399
+# This is used under the CC BY-SA 4.0 license:
+# https://creativecommons.org/licenses/by-sa/4.0/
+
+#!/bin/bash
+if [ -x $0.local ]; then
+    $0.local "$@" || exit $?
+fi
+if [ -x scripts/git/$(basename $0) ]; then
+    scripts/git/$(basename $0) "$@" || exit $?
+fi


### PR DESCRIPTION
## Description
This PR is simple, it adds a git-commit hook that runs `cargo fmt` every time any code changes are committed via `git commit`


#### GitHub Issue: N/A

### Changes
* Add git-commit hook that runs 'cargo fmt' when committing code changes
* Updates README.md to list how to install the git-commit hooks

### Testing Strategy
Run `scripts/create-git-hooks`, modify a piece of Rust code, and observe that `cargo fmt` fixes the formatting if necessary.


### Concerns
None