### PR TITLE
More robust handling of responses from NINA-FW

### DIFF
--- a/cross/send_data_tcp/src/main.rs
+++ b/cross/send_data_tcp/src/main.rs
@@ -171,11 +171,7 @@ fn main() -> ! {
                         mode,
                         &mut delay,
                         &mut |tcp_client| {
-                            defmt::info!(
-                                "TCP connection to {:?}:{:?} successful",
-                                hostname,
-                                port
-                            );
+                            defmt::info!("TCP connection to {:?}:{:?} successful", hostname, port);
                             defmt::info!("Hostname: {:?}", tcp_client.server_hostname());
                             defmt::info!("Sending HTTP Document: {:?}", http_document.as_str());
                             match tcp_client.send_data(&http_document) {

--- a/esp32-wroom-rp/src/gpio.rs
+++ b/esp32-wroom-rp/src/gpio.rs
@@ -30,6 +30,8 @@
 //! };
 //! ```
 
+use core::hint;
+
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 
@@ -131,13 +133,13 @@ where
 
     fn wait_for_esp_ready(&self) {
         while !self.get_esp_ready() {
-            //cortex_m::asm::nop(); // Make sure rustc doesn't optimize this loop out
+            hint::spin_loop(); // Make sure rustc doesn't optimize this loop out
         }
     }
 
     fn wait_for_esp_ack(&self) {
         while !self.get_esp_ack() {
-            //cortex_m::asm::nop(); // Make sure rustc doesn't optimize this loop out
+            hint::spin_loop(); // Make sure rustc doesn't optimize this loop out
         }
     }
 

--- a/esp32-wroom-rp/src/lib.rs
+++ b/esp32-wroom-rp/src/lib.rs
@@ -163,8 +163,6 @@ use network::NetworkError;
 
 use protocol::ProtocolError;
 
-const ARRAY_LENGTH_PLACEHOLDER: usize = 8;
-
 /// Highest level error types for this crate.
 #[derive(Debug, Eq, PartialEq)]
 pub enum Error {
@@ -212,17 +210,15 @@ pub struct FirmwareVersion {
 }
 
 impl FirmwareVersion {
-    fn new(version: [u8; ARRAY_LENGTH_PLACEHOLDER]) -> FirmwareVersion {
+    fn new(version: &[u8]) -> FirmwareVersion {
         Self::parse(version)
     }
 
     // Takes in 8 bytes (e.g. 1.7.4) and returns a FirmwareVersion instance
-    fn parse(version: [u8; ARRAY_LENGTH_PLACEHOLDER]) -> FirmwareVersion {
-        let major_version: u8;
-        let minor_version: u8;
-        let patch_version: u8;
-
-        [major_version, _, minor_version, _, patch_version, _, _, _] = version;
+    fn parse(version: &[u8]) -> FirmwareVersion {
+        let major_version: u8 = version[0];
+        let minor_version: u8 = version[2];
+        let patch_version: u8 = version[4];
 
         FirmwareVersion {
             major: major_version,
@@ -248,8 +244,7 @@ mod tests {
 
     #[test]
     fn firmware_new_returns_a_populated_firmware_struct() {
-        let firmware_version: FirmwareVersion =
-            FirmwareVersion::new([0x1, 0x2e, 0x7, 0x2e, 0x4, 0x0, 0x0, 0x0]);
+        let firmware_version: FirmwareVersion = FirmwareVersion::new(&[0x1, 0x2e, 0x7, 0x2e, 0x4]);
 
         assert_eq!(
             firmware_version,

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -24,7 +24,7 @@ pub(crate) const MAX_NINA_SMALL_ARRAY_PARAM_BUFFER_LENGTH: usize = 255;
 pub(crate) const MAX_NINA_LARGE_ARRAY_PARAM_BUFFER_LENGTH: usize = 1024;
 
 // The maximum length that a 2-byte length NINA response can be
-pub(crate) const MAX_NINA_RESPONSE_LENGTH: usize = 32;
+pub(crate) const MAX_NINA_RESPONSE_LENGTH: usize = 1064;
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -24,7 +24,11 @@ pub(crate) const MAX_NINA_SMALL_ARRAY_PARAM_BUFFER_LENGTH: usize = 255;
 pub(crate) const MAX_NINA_LARGE_ARRAY_PARAM_BUFFER_LENGTH: usize = 1024;
 
 // The maximum length that a 2-byte length NINA response can be
-pub(crate) const MAX_NINA_RESPONSE_LENGTH: usize = 1064;
+pub(crate) const MAX_NINA_RESPONSE_LENGTH: usize = 1024;
+
+// TODO: unalias this type and turn into a full wrapper struct
+/// Provides a byte buffer to hold responses returned from NINA-FW
+pub type NinaResponseBuffer = [u8; MAX_NINA_RESPONSE_LENGTH];
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
@@ -400,11 +404,7 @@ pub(crate) trait ProtocolInterface {
     ) -> Result<(), Error>;
     fn stop_client_tcp(&mut self, socket: Socket, _mode: &TransportMode) -> Result<(), Error>;
     fn get_client_state_tcp(&mut self, socket: Socket) -> Result<ConnectionState, Error>;
-    fn send_data(
-        &mut self,
-        data: &str,
-        socket: Socket,
-    ) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error>;
+    fn send_data(&mut self, data: &str, socket: Socket) -> Result<[u8; 1], Error>;
 }
 
 #[derive(Debug)]

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -70,29 +70,34 @@ pub(crate) trait NinaParam {
 }
 
 // Used for single byte params
+#[derive(PartialEq, Debug)]
 pub(crate) struct NinaByteParam {
     length: u8,
     data: <NinaByteParam as NinaConcreteParam>::DataBuffer,
 }
 
 // Used for 2-byte params
+#[derive(PartialEq, Debug)]
 pub(crate) struct NinaWordParam {
     length: u8,
     data: <NinaWordParam as NinaConcreteParam>::DataBuffer,
 }
 
 // Used for params that are smaller than 255 bytes
+#[derive(PartialEq, Debug)]
 pub(crate) struct NinaSmallArrayParam {
     length: u8,
     data: <NinaSmallArrayParam as NinaConcreteParam>::DataBuffer,
 }
 
 // Used for params that can be larger than 255 bytes up to MAX_NINA_PARAM_LENGTH
+#[derive(PartialEq, Debug)]
 pub(crate) struct NinaLargeArrayParam {
     length: u16,
     data: <NinaLargeArrayParam as NinaConcreteParam>::DataBuffer,
 }
 
+#[derive(PartialEq, Debug)]
 pub(crate) struct NinaAbstractParam {
     // Byte representation of length of data
     length_as_bytes: [u8; 2],
@@ -441,5 +446,103 @@ impl Format for ProtocolError {
             ProtocolError::TooManyParameters => write!(fmt, "Encountered too many parameters for a NINA command while communicating with ESP32 target."),
             ProtocolError::PayloadTooLarge => write!(fmt, "The payload is larger than the max buffer size allowed for a NINA parameter while communicating with ESP32 target."),
         }
+    }
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::*;
+    use core::str;
+
+    #[test]
+    fn nina_byte_param_new_returns_payload_too_large_error_when_given_too_many_bytes() {
+        let str_slice: &str = "too many bytes";
+        let result = NinaByteParam::new(str_slice);
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
+    }
+
+    #[test]
+    fn nina_byte_param_from_bytes_returns_payload_too_large_error_when_given_too_many_bytes() {
+        let bytes: [u8; 2] = [0; 2];
+        let result = NinaByteParam::from_bytes(&bytes);
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
+    }
+
+    #[test]
+    fn nina_word_param_new_returns_payload_too_large_error_when_given_too_many_bytes() {
+        let str_slice: &str = "too many bytes";
+        let result = NinaWordParam::new(str_slice);
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
+    }
+
+    #[test]
+    fn nina_word_param_from_bytes_returns_payload_too_large_error_when_given_too_many_bytes() {
+        let bytes: [u8; 3] = [0; 3];
+        let result = NinaWordParam::from_bytes(&bytes);
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
+    }
+
+    #[test]
+    fn nina_small_array_param_new_returns_payload_too_large_error_when_given_too_many_bytes() {
+        let bytes = [0xA; 256];
+        let str_slice: &str = str::from_utf8(&bytes).unwrap();
+        let result = NinaSmallArrayParam::new(str_slice);
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
+    }
+
+    #[test]
+    fn nina_small_array_param_from_bytes_returns_payload_too_large_error_when_given_too_many_bytes()
+    {
+        let bytes: [u8; 256] = [0xA; 256];
+        let result = NinaSmallArrayParam::from_bytes(&bytes);
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
+    }
+
+    #[test]
+    fn nina_large_array_param_new_returns_payload_too_large_error_when_given_too_many_bytes() {
+        let bytes = [0xA; 1025];
+        let str_slice: &str = str::from_utf8(&bytes).unwrap();
+        let result = NinaLargeArrayParam::new(str_slice);
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
+    }
+
+    #[test]
+    fn nina_large_array_param_from_bytes_returns_payload_too_large_error_when_given_too_many_bytes()
+    {
+        let bytes: [u8; 1025] = [0xA; 1025];
+        let result = NinaLargeArrayParam::from_bytes(&bytes);
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
     }
 }

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -51,7 +51,7 @@ where
     // Length of parameter in bytes
     type LengthAsBytes: IntoIterator<Item = u8>;
 
-    fn new(data: &str) -> Self;
+    fn new(data: &str) -> Result<Self, Error>;
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error>;
 
@@ -171,17 +171,21 @@ impl NinaConcreteParam for NinaByteParam {
     type DataBuffer = Vec<u8, MAX_NINA_BYTE_PARAM_BUFFER_LENGTH>;
     type LengthAsBytes = [u8; 1];
 
-    fn new(data: &str) -> Self {
+    fn new(data: &str) -> Result<Self, Error> {
+        if data.len() > MAX_NINA_BYTE_PARAM_BUFFER_LENGTH {
+            return Err(ProtocolError::PayloadTooLarge.into());
+        }
+
         let data_as_bytes: Self::DataBuffer = String::from(data).into_bytes();
-        Self {
+        Ok(Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
-        }
+        })
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() > MAX_NINA_BYTE_PARAM_BUFFER_LENGTH {
-            return Err(ProtocolError::TooManyParameters.into());
+            return Err(ProtocolError::PayloadTooLarge.into());
         }
 
         let mut data_as_bytes: Self::DataBuffer = Vec::new();
@@ -218,17 +222,21 @@ impl NinaConcreteParam for NinaWordParam {
     type DataBuffer = Vec<u8, MAX_NINA_WORD_PARAM_BUFFER_LENGTH>;
     type LengthAsBytes = [u8; 1];
 
-    fn new(data: &str) -> Self {
+    fn new(data: &str) -> Result<Self, Error> {
+        if data.len() > MAX_NINA_WORD_PARAM_BUFFER_LENGTH {
+            return Err(ProtocolError::PayloadTooLarge.into());
+        }
+
         let data_as_bytes: Self::DataBuffer = String::from(data).into_bytes();
-        Self {
+        Ok(Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
-        }
+        })
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() > MAX_NINA_WORD_PARAM_BUFFER_LENGTH {
-            return Err(ProtocolError::TooManyParameters.into());
+            return Err(ProtocolError::PayloadTooLarge.into());
         }
 
         let mut data_as_bytes: Self::DataBuffer = Vec::new();
@@ -265,17 +273,21 @@ impl NinaConcreteParam for NinaSmallArrayParam {
     type DataBuffer = Vec<u8, MAX_NINA_SMALL_ARRAY_PARAM_BUFFER_LENGTH>;
     type LengthAsBytes = [u8; 1];
 
-    fn new(data: &str) -> Self {
+    fn new(data: &str) -> Result<Self, Error> {
+        if data.len() > MAX_NINA_SMALL_ARRAY_PARAM_BUFFER_LENGTH {
+            return Err(ProtocolError::PayloadTooLarge.into());
+        }
+
         let data_as_bytes: Self::DataBuffer = String::from(data).into_bytes();
-        Self {
+        Ok(Self {
             length: data_as_bytes.len() as u8,
             data: data_as_bytes,
-        }
+        })
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() > MAX_NINA_SMALL_ARRAY_PARAM_BUFFER_LENGTH {
-            return Err(ProtocolError::TooManyParameters.into());
+            return Err(ProtocolError::PayloadTooLarge.into());
         }
 
         let mut data_as_bytes: Self::DataBuffer = Vec::new();
@@ -312,17 +324,21 @@ impl NinaConcreteParam for NinaLargeArrayParam {
     type DataBuffer = Vec<u8, MAX_NINA_LARGE_ARRAY_PARAM_BUFFER_LENGTH>;
     type LengthAsBytes = [u8; 2];
 
-    fn new(data: &str) -> Self {
+    fn new(data: &str) -> Result<Self, Error> {
+        if data.len() > MAX_NINA_LARGE_ARRAY_PARAM_BUFFER_LENGTH {
+            return Err(ProtocolError::PayloadTooLarge.into());
+        }
+
         let data_as_bytes: Self::DataBuffer = String::from(data).into_bytes();
-        Self {
+        Ok(Self {
             length: data_as_bytes.len() as u16,
             data: data_as_bytes,
-        }
+        })
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() > MAX_NINA_LARGE_ARRAY_PARAM_BUFFER_LENGTH {
-            return Err(ProtocolError::TooManyParameters.into());
+            return Err(ProtocolError::PayloadTooLarge.into());
         }
 
         let mut data_as_bytes: Self::DataBuffer = Vec::new();

--- a/esp32-wroom-rp/src/protocol.rs
+++ b/esp32-wroom-rp/src/protocol.rs
@@ -59,36 +59,6 @@ pub(crate) trait NinaConcreteParam {
     fn length(&self) -> u16;
 }
 
-// Used for Nina protocol commands with no parameters
-pub(crate) struct NinaNoParams {
-    _placeholder: u8,
-}
-
-impl NinaConcreteParam for NinaNoParams {
-    type DataBuffer = [u8; 0];
-    type LengthAsBytes = [u8; 0];
-
-    fn new(_data: &str) -> Self {
-        Self { _placeholder: 0 }
-    }
-
-    fn from_bytes(_bytes: &[u8]) -> Self {
-        Self { _placeholder: 0 }
-    }
-
-    fn data(&self) -> &[u8] {
-        &[0u8]
-    }
-
-    fn length_as_bytes(&self) -> Self::LengthAsBytes {
-        []
-    }
-
-    fn length(&self) -> u16 {
-        0u16
-    }
-}
-
 pub(crate) trait NinaParam {
     fn length_as_bytes(&self) -> [u8; 2];
     fn data(&self) -> &[u8];
@@ -147,17 +117,6 @@ impl NinaParam for NinaAbstractParam {
 
     fn length_size(&self) -> u8 {
         self.length_size
-    }
-}
-
-impl From<NinaNoParams> for NinaAbstractParam {
-    fn from(concrete_param: NinaNoParams) -> NinaAbstractParam {
-        NinaAbstractParam {
-            length_as_bytes: [0, 0],
-            data: Vec::from_slice(concrete_param.data()).unwrap(),
-            length: concrete_param.length(),
-            length_size: 0,
-        }
     }
 }
 

--- a/esp32-wroom-rp/src/protocol/operation.rs
+++ b/esp32-wroom-rp/src/protocol/operation.rs
@@ -24,9 +24,9 @@ impl Operation<NinaAbstractParam> {
     // Pushes a new param into the internal `params` Vector which
     // builds up an internal byte stream representing one Nina command
     // on the data bus.
-    pub fn param(mut self, param: NinaAbstractParam) -> Self {
+    pub fn param<P: Into<NinaAbstractParam>>(mut self, param: P) -> Self {
         // FIXME: Vec::push() will return T when it is full, handle this gracefully
-        self.params.push(param).unwrap_or(());
+        self.params.push(param.into()).unwrap_or(());
         self
     }
 }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -15,8 +15,8 @@ use super::network::{ConnectionState, IpAddress, NetworkError, Port, Socket, Tra
 use super::protocol::operation::Operation;
 use super::protocol::{
     NinaByteParam, NinaCommand, NinaConcreteParam, NinaLargeArrayParam, NinaParam,
-    NinaProtocolHandler, NinaSmallArrayParam, NinaWordParam, ProtocolError, ProtocolInterface,
-    MAX_NINA_PARAMS, MAX_NINA_RESPONSE_LENGTH,
+    NinaProtocolHandler, NinaResponseBuffer, NinaSmallArrayParam, NinaWordParam, ProtocolError,
+    ProtocolInterface, MAX_NINA_PARAMS, MAX_NINA_RESPONSE_LENGTH,
 };
 use super::wifi::ConnectionStatus;
 use super::{Error, FirmwareVersion};
@@ -59,12 +59,8 @@ where
 
     fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error> {
         let operation = Operation::new(NinaCommand::SetPassphrase)
-            .param(NinaSmallArrayParam::new(ssid).unwrap_or_default().into())
-            .param(
-                NinaSmallArrayParam::new(passphrase)
-                    .unwrap_or_default()
-                    .into(),
-            );
+            .param(NinaSmallArrayParam::new(ssid)?)
+            .param(NinaSmallArrayParam::new(passphrase)?);
 
         self.execute(&operation)?;
 
@@ -85,7 +81,7 @@ where
     fn disconnect(&mut self) -> Result<(), Error> {
         let dummy_param = NinaByteParam::from_bytes(&[ControlByte::Dummy as u8]);
         let operation =
-            Operation::new(NinaCommand::Disconnect).param(dummy_param.unwrap_or_default().into());
+            Operation::new(NinaCommand::Disconnect).param(dummy_param.unwrap_or_default());
 
         self.execute(&operation)?;
 
@@ -98,17 +94,9 @@ where
         // FIXME: refactor Operation so it can take different NinaParam types
         let operation = Operation::new(NinaCommand::SetDNSConfig)
             // FIXME: first param should be able to be a NinaByteParam:
-            .param(NinaByteParam::from_bytes(&[1]).unwrap_or_default().into())
-            .param(
-                NinaSmallArrayParam::from_bytes(&ip1)
-                    .unwrap_or_default()
-                    .into(),
-            )
-            .param(
-                NinaSmallArrayParam::from_bytes(&ip2.unwrap_or_default())
-                    .unwrap_or_default()
-                    .into(),
-            );
+            .param(NinaByteParam::from_bytes(&[1])?)
+            .param(NinaSmallArrayParam::from_bytes(&ip1)?)
+            .param(NinaSmallArrayParam::from_bytes(&ip2.unwrap_or_default())?);
 
         self.execute(&operation)?;
 
@@ -118,11 +106,8 @@ where
     }
 
     fn req_host_by_name(&mut self, hostname: &str) -> Result<u8, Error> {
-        let operation = Operation::new(NinaCommand::ReqHostByName).param(
-            NinaSmallArrayParam::new(hostname)
-                .unwrap_or_default()
-                .into(),
-        );
+        let operation =
+            Operation::new(NinaCommand::ReqHostByName).param(NinaSmallArrayParam::new(hostname)?);
 
         self.execute(&operation)?;
 
@@ -135,7 +120,7 @@ where
         Ok(result[0])
     }
 
-    fn get_host_by_name(&mut self) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error> {
+    fn get_host_by_name(&mut self) -> Result<NinaResponseBuffer, Error> {
         let operation = Operation::new(NinaCommand::GetHostByName);
 
         self.execute(&operation)?;
@@ -182,26 +167,10 @@ where
     ) -> Result<(), Error> {
         let port_as_bytes = [((port & 0xff00) >> 8) as u8, (port & 0xff) as u8];
         let operation = Operation::new(NinaCommand::StartClientTcp)
-            .param(
-                NinaSmallArrayParam::from_bytes(&ip)
-                    .unwrap_or_default()
-                    .into(),
-            )
-            .param(
-                NinaWordParam::from_bytes(&port_as_bytes)
-                    .unwrap_or_default()
-                    .into(),
-            )
-            .param(
-                NinaByteParam::from_bytes(&[socket])
-                    .unwrap_or_default()
-                    .into(),
-            )
-            .param(
-                NinaByteParam::from_bytes(&[*mode as u8])
-                    .unwrap_or_default()
-                    .into(),
-            );
+            .param(NinaSmallArrayParam::from_bytes(&ip)?)
+            .param(NinaWordParam::from_bytes(&port_as_bytes)?)
+            .param(NinaByteParam::from_bytes(&[socket])?)
+            .param(NinaByteParam::from_bytes(&[*mode as u8])?);
 
         self.execute(&operation)?;
 
@@ -216,11 +185,8 @@ where
     // TODO: passing in TransportMode but not using, for now. It will become a way
     // of stopping the right kind of client (e.g. TCP, vs UDP)
     fn stop_client_tcp(&mut self, socket: Socket, _mode: &TransportMode) -> Result<(), Error> {
-        let operation = Operation::new(NinaCommand::StopClientTcp).param(
-            NinaByteParam::from_bytes(&[socket])
-                .unwrap_or_default()
-                .into(),
-        );
+        let operation =
+            Operation::new(NinaCommand::StopClientTcp).param(NinaByteParam::from_bytes(&[socket])?);
 
         self.execute(&operation)?;
 
@@ -233,11 +199,8 @@ where
     }
 
     fn get_client_state_tcp(&mut self, socket: Socket) -> Result<ConnectionState, Error> {
-        let operation = Operation::new(NinaCommand::GetClientStateTcp).param(
-            NinaByteParam::from_bytes(&[socket])
-                .unwrap_or_default()
-                .into(),
-        );
+        let operation = Operation::new(NinaCommand::GetClientStateTcp)
+            .param(NinaByteParam::from_bytes(&[socket])?);
 
         self.execute(&operation)?;
 
@@ -247,24 +210,16 @@ where
         Ok(ConnectionState::from(result[0]))
     }
 
-    fn send_data(
-        &mut self,
-        data: &str,
-        socket: Socket,
-    ) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error> {
+    fn send_data(&mut self, data: &str, socket: Socket) -> Result<[u8; 1], Error> {
         let operation = Operation::new(NinaCommand::SendDataTcp)
-            .param(
-                NinaLargeArrayParam::from_bytes(&[socket])
-                    .unwrap_or_default()
-                    .into(),
-            )
-            .param(NinaLargeArrayParam::new(data).unwrap_or_default().into());
+            .param(NinaLargeArrayParam::from_bytes(&[socket])?)
+            .param(NinaLargeArrayParam::new(data)?);
 
         self.execute(&operation)?;
 
         let result = self.receive(&operation, 1)?;
 
-        Ok(result)
+        Ok([result[0]])
     }
 }
 
@@ -313,7 +268,7 @@ where
         &mut self,
         operation: &Operation<P>,
         expected_num_params: u8,
-    ) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error> {
+    ) -> Result<NinaResponseBuffer, Error> {
         self.control_pins.wait_for_esp_select();
 
         self.check_response_ready(&operation.command, expected_num_params)?;
@@ -343,15 +298,14 @@ where
         Ok(())
     }
 
-    fn read_response(&mut self) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error> {
+    fn read_response(&mut self) -> Result<NinaResponseBuffer, Error> {
         let response_length_in_bytes = self.get_byte().ok().unwrap() as usize;
 
         if response_length_in_bytes > MAX_NINA_PARAMS {
             return Err(ProtocolError::TooManyParameters.into());
         }
 
-        let mut response_param_buffer: [u8; MAX_NINA_RESPONSE_LENGTH] =
-            [0; MAX_NINA_RESPONSE_LENGTH];
+        let mut response_param_buffer: NinaResponseBuffer = [0; MAX_NINA_RESPONSE_LENGTH];
         if response_length_in_bytes > 0 {
             response_param_buffer =
                 self.read_response_bytes(response_param_buffer, response_length_in_bytes)?;
@@ -382,9 +336,9 @@ where
 
     fn read_response_bytes(
         &mut self,
-        mut response_param_buffer: [u8; MAX_NINA_RESPONSE_LENGTH],
+        mut response_param_buffer: NinaResponseBuffer,
         response_length_in_bytes: usize,
-    ) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error> {
+    ) -> Result<NinaResponseBuffer, Error> {
         for i in 0..response_length_in_bytes {
             response_param_buffer[i] = self.get_byte().ok().unwrap()
         }
@@ -450,5 +404,85 @@ where
             self.get_byte().ok();
             command_size += 1;
         }
+    }
+}
+
+#[cfg(test)]
+mod spi_tests {
+    use super::*;
+
+    use crate::gpio::EspControlPins;
+    use crate::Error;
+    use core::cell::RefCell;
+    use core::str;
+    use embedded_hal::blocking::spi::Transfer;
+    use embedded_hal::digital::v2::{InputPin, OutputPin, PinState};
+
+    struct TransferMock {}
+
+    impl Transfer<u8> for TransferMock {
+        type Error = Error;
+        fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Error> {
+            Ok(words)
+        }
+    }
+
+    struct OutputPinMock {}
+
+    impl OutputPin for OutputPinMock {
+        type Error = Error;
+
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn set_state(&mut self, _state: PinState) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    struct InputPinMock {}
+
+    impl InputPin for InputPinMock {
+        type Error = Error;
+
+        fn is_high(&self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+
+        fn is_low(&self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+    }
+
+    #[test]
+    fn too_large_of_a_nina_param_throws_error() {
+        let bytes = [0xA; 256];
+        let str_slice: &str = str::from_utf8(&bytes).unwrap();
+
+        let control_pins = EspControlPins {
+            cs: OutputPinMock {},
+            gpio0: OutputPinMock {},
+            resetn: OutputPinMock {},
+            ack: InputPinMock {},
+        };
+
+        let transfer_mock = TransferMock {};
+
+        let mut protocol_handler = NinaProtocolHandler {
+            bus: RefCell::new(transfer_mock),
+            control_pins: control_pins,
+        };
+
+        let result = protocol_handler.set_passphrase(str_slice, "");
+
+        assert_eq!(
+            result.unwrap_err(),
+            Error::Protocol(ProtocolError::PayloadTooLarge)
+        )
     }
 }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -339,8 +339,11 @@ where
         mut response_param_buffer: NinaResponseBuffer,
         response_length_in_bytes: usize,
     ) -> Result<NinaResponseBuffer, Error> {
-        for i in 0..response_length_in_bytes {
-            response_param_buffer[i] = self.get_byte().ok().unwrap()
+        for byte in response_param_buffer
+            .iter_mut()
+            .take(response_length_in_bytes)
+        {
+            *byte = self.get_byte().ok().unwrap();
         }
         Ok(response_param_buffer)
     }

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -80,7 +80,8 @@ where
 
     fn disconnect(&mut self) -> Result<(), Error> {
         let dummy_param = NinaByteParam::from_bytes(&[ControlByte::Dummy as u8]);
-        let operation = Operation::new(NinaCommand::Disconnect).param(dummy_param.into());
+        let operation =
+            Operation::new(NinaCommand::Disconnect).param(dummy_param.unwrap_or_default().into());
 
         self.execute(&operation)?;
 
@@ -93,9 +94,17 @@ where
         // FIXME: refactor Operation so it can take different NinaParam types
         let operation = Operation::new(NinaCommand::SetDNSConfig)
             // FIXME: first param should be able to be a NinaByteParam:
-            .param(NinaByteParam::from_bytes(&[1]).into())
-            .param(NinaSmallArrayParam::from_bytes(&ip1).into())
-            .param(NinaSmallArrayParam::from_bytes(&ip2.unwrap_or_default()).into());
+            .param(NinaByteParam::from_bytes(&[1]).unwrap_or_default().into())
+            .param(
+                NinaSmallArrayParam::from_bytes(&ip1)
+                    .unwrap_or_default()
+                    .into(),
+            )
+            .param(
+                NinaSmallArrayParam::from_bytes(&ip2.unwrap_or_default())
+                    .unwrap_or_default()
+                    .into(),
+            );
 
         self.execute(&operation)?;
 
@@ -166,10 +175,26 @@ where
     ) -> Result<(), Error> {
         let port_as_bytes = [((port & 0xff00) >> 8) as u8, (port & 0xff) as u8];
         let operation = Operation::new(NinaCommand::StartClientTcp)
-            .param(NinaSmallArrayParam::from_bytes(&ip).into())
-            .param(NinaWordParam::from_bytes(&port_as_bytes).into())
-            .param(NinaByteParam::from_bytes(&[socket]).into())
-            .param(NinaByteParam::from_bytes(&[*mode as u8]).into());
+            .param(
+                NinaSmallArrayParam::from_bytes(&ip)
+                    .unwrap_or_default()
+                    .into(),
+            )
+            .param(
+                NinaWordParam::from_bytes(&port_as_bytes)
+                    .unwrap_or_default()
+                    .into(),
+            )
+            .param(
+                NinaByteParam::from_bytes(&[socket])
+                    .unwrap_or_default()
+                    .into(),
+            )
+            .param(
+                NinaByteParam::from_bytes(&[*mode as u8])
+                    .unwrap_or_default()
+                    .into(),
+            );
 
         self.execute(&operation)?;
 
@@ -184,8 +209,11 @@ where
     // TODO: passing in TransportMode but not using, for now. It will become a way
     // of stopping the right kind of client (e.g. TCP, vs UDP)
     fn stop_client_tcp(&mut self, socket: Socket, _mode: &TransportMode) -> Result<(), Error> {
-        let operation = Operation::new(NinaCommand::StopClientTcp)
-            .param(NinaByteParam::from_bytes(&[socket]).into());
+        let operation = Operation::new(NinaCommand::StopClientTcp).param(
+            NinaByteParam::from_bytes(&[socket])
+                .unwrap_or_default()
+                .into(),
+        );
 
         self.execute(&operation)?;
 
@@ -198,8 +226,11 @@ where
     }
 
     fn get_client_state_tcp(&mut self, socket: Socket) -> Result<ConnectionState, Error> {
-        let operation = Operation::new(NinaCommand::GetClientStateTcp)
-            .param(NinaByteParam::from_bytes(&[socket]).into());
+        let operation = Operation::new(NinaCommand::GetClientStateTcp).param(
+            NinaByteParam::from_bytes(&[socket])
+                .unwrap_or_default()
+                .into(),
+        );
 
         self.execute(&operation)?;
 
@@ -215,7 +246,11 @@ where
         socket: Socket,
     ) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error> {
         let operation = Operation::new(NinaCommand::SendDataTcp)
-            .param(NinaLargeArrayParam::from_bytes(&[socket]).into())
+            .param(
+                NinaLargeArrayParam::from_bytes(&[socket])
+                    .unwrap_or_default()
+                    .into(),
+            )
             .param(NinaLargeArrayParam::new(data).into());
 
         self.execute(&operation)?;

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -327,8 +327,8 @@ where
         let mut response_param_buffer: [u8; MAX_NINA_RESPONSE_LENGTH] =
             [0; MAX_NINA_RESPONSE_LENGTH];
         if number_of_params_to_read > 0 {
-            for (index, _) in response_param_buffer.into_iter().enumerate() {
-                response_param_buffer[index] = self.get_byte().ok().unwrap()
+            for i in 0..number_of_params_to_read {
+                response_param_buffer[i] = self.get_byte().ok().unwrap()
             }
         }
 

--- a/esp32-wroom-rp/src/spi.rs
+++ b/esp32-wroom-rp/src/spi.rs
@@ -59,8 +59,12 @@ where
 
     fn set_passphrase(&mut self, ssid: &str, passphrase: &str) -> Result<(), Error> {
         let operation = Operation::new(NinaCommand::SetPassphrase)
-            .param(NinaSmallArrayParam::new(ssid).into())
-            .param(NinaSmallArrayParam::new(passphrase).into());
+            .param(NinaSmallArrayParam::new(ssid).unwrap_or_default().into())
+            .param(
+                NinaSmallArrayParam::new(passphrase)
+                    .unwrap_or_default()
+                    .into(),
+            );
 
         self.execute(&operation)?;
 
@@ -114,8 +118,11 @@ where
     }
 
     fn req_host_by_name(&mut self, hostname: &str) -> Result<u8, Error> {
-        let operation = Operation::new(NinaCommand::ReqHostByName)
-            .param(NinaSmallArrayParam::new(hostname).into());
+        let operation = Operation::new(NinaCommand::ReqHostByName).param(
+            NinaSmallArrayParam::new(hostname)
+                .unwrap_or_default()
+                .into(),
+        );
 
         self.execute(&operation)?;
 
@@ -251,7 +258,7 @@ where
                     .unwrap_or_default()
                     .into(),
             )
-            .param(NinaLargeArrayParam::new(data).into());
+            .param(NinaLargeArrayParam::new(data).unwrap_or_default().into());
 
         self.execute(&operation)?;
 

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -50,7 +50,7 @@ use super::gpio::EspControlInterface;
 use super::network::{
     ConnectionState, Hostname, IpAddress, NetworkError, Port, Socket, TransportMode,
 };
-use super::protocol::{NinaProtocolHandler, ProtocolInterface, MAX_NINA_RESPONSE_LENGTH};
+use super::protocol::{NinaProtocolHandler, ProtocolInterface};
 use super::wifi::Wifi;
 use super::Error;
 
@@ -176,7 +176,7 @@ where
     }
 
     /// Send a string slice of data to a connected server.
-    pub fn send_data(&mut self, data: &str) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error> {
+    pub fn send_data(&mut self, data: &str) -> Result<[u8; 1], Error> {
         self.protocol_handler
             .send_data(data, self.socket.unwrap_or_default())
     }

--- a/esp32-wroom-rp/src/tcp_client.rs
+++ b/esp32-wroom-rp/src/tcp_client.rs
@@ -50,9 +50,9 @@ use super::gpio::EspControlInterface;
 use super::network::{
     ConnectionState, Hostname, IpAddress, NetworkError, Port, Socket, TransportMode,
 };
-use super::protocol::{NinaProtocolHandler, ProtocolInterface};
+use super::protocol::{NinaProtocolHandler, ProtocolInterface, MAX_NINA_RESPONSE_LENGTH};
 use super::wifi::Wifi;
-use super::{Error, ARRAY_LENGTH_PLACEHOLDER};
+use super::Error;
 
 const MAX_HOSTNAME_LENGTH: usize = 255;
 
@@ -176,7 +176,7 @@ where
     }
 
     /// Send a string slice of data to a connected server.
-    pub fn send_data(&mut self, data: &str) -> Result<[u8; ARRAY_LENGTH_PLACEHOLDER], Error> {
+    pub fn send_data(&mut self, data: &str) -> Result<[u8; MAX_NINA_RESPONSE_LENGTH], Error> {
         self.protocol_handler
             .send_data(data, self.socket.unwrap_or_default())
     }

--- a/host-tests/tests/spi.rs
+++ b/host-tests/tests/spi.rs
@@ -163,7 +163,10 @@ fn invalid_command_induces_nina_protocol_version_mismatch_error() {
     let mut invalid_command_expactations = vec![
         // wait_response_cmd()
         // read start command (should be ee)
+        // NINA Firmware send an error byte (0xef) followed by 0x00 and end 0xee
         spi::Transaction::transfer(vec![0xff], vec![0xef]),
+        spi::Transaction::transfer(vec![0xff], vec![0x00]),
+        spi::Transaction::transfer(vec![0xff], vec![0xee]),
     ];
     expectations.append(&mut invalid_command_expactations);
 


### PR DESCRIPTION
## Description
This PR aims to create a more robust handling of replies & responses back from the NINA-FW on the ESP32 such that we're ready to implement a full handling of a response for issuing a `ProtocolInterface::send_data()`, after an HTTP GET, for example.

#### GitHub Issue: Related to #61

### Changes
* Adds a max size check on creating a new NinaParam type and related unit tests
* Adds an architecture-independent CPU-friendly `spin_loop()` in `wait_for_esp_ready()` and `wait_for_esp_ack()`
* Ensures that we consume all 3 bytes when we encounter a `ControlByte::Error` from NINA-FW
* Breaks `NinaProtocolHandler::receive()` out into logical child functions to improve readability and maintainability 

### Testing Strategy
1. Run all example applications in `cross/` on a target device
2. Run `cargo test` and ensure all tests pass


### Concerns
None